### PR TITLE
Fix namespace std

### DIFF
--- a/CPP_Demo/main.cpp
+++ b/CPP_Demo/main.cpp
@@ -61,7 +61,7 @@ public:
     double value;
 
     // Task
-    thread *t;
+    std::thread *t;
 
     SigGen(const char* instanceName, uint32_t cycleTimeUs, double ampl, double offset, double phase, double period) : XcpObject(instanceName,"SigGen",sizeof(SigGen)) {
 
@@ -76,7 +76,7 @@ public:
         value = 0; 
 
         // Start ECU task thread
-        t = new thread([this]() { task(); });
+        t = new std::thread([this]() { task(); });
     }
          
     void calcMinMax(double v) { // track the task with current minimum and maximum value
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
     // The constructor of SigGen will create an instance amd an associated XCP event
     SigGen* sigGen[10];
     for (int i = 0; i <= 9; i++) {
-        string* s = new string("SigGen"); s->append(to_string(i+1));
+        std::string* s = new std::string("SigGen"); s->append(std::to_string(i+1));
         sigGen[i] = new SigGen((char*)s->c_str(), 2000, 100.0-i*5, 0.0, i*M_PI/15.0, 2.0);
     }
     

--- a/CPP_Demo/main.h
+++ b/CPP_Demo/main.h
@@ -84,6 +84,3 @@
 #include <string>
 #include <vector>
 #include <vector>
-using namespace std;
-
-

--- a/src/xcp.cpp
+++ b/src/xcp.cpp
@@ -143,12 +143,12 @@ uint16_t Xcp::createEvent(XcpEventDescriptor event) {
     return XcpCreateEvent(event.name, event.cycleTime, event.priority, event.sampleCount, event.size);
 }
 
-vector<Xcp::XcpEventDescriptor>* Xcp::getEventList() {
+std::vector<Xcp::XcpEventDescriptor>* Xcp::getEventList() {
 
     uint16_t evtCount = 0;
     tXcpEvent* evtList = XcpGetEventList(&evtCount);
 
-    vector<Xcp::XcpEventDescriptor>* l = new vector<Xcp::XcpEventDescriptor>();
+    std::vector<Xcp::XcpEventDescriptor>* l = new std::vector<Xcp::XcpEventDescriptor>();
     for (int i = 0; i < evtCount; i++) {
         uint64_t ns = evtList[i].timeCycle;
         uint8_t exp = evtList[i].timeUnit;

--- a/src/xcp.hpp
+++ b/src/xcp.hpp
@@ -87,7 +87,7 @@ public:
 
 	void clearEventList(); // Event handling
 	uint16_t createEvent(XcpEventDescriptor event);
-	vector<XcpEventDescriptor>* getEventList();
+	std::vector<XcpEventDescriptor>* getEventList();
 
 	void event(uint16_t event);    // Event trigger
 	void eventExt(uint16_t event, uint8_t* base);


### PR DESCRIPTION
### What?

remove using namespace std in CPP_Demo/main.h
adjust namespaces in xcp.hpp and xcp.cpp

### Why?

main.h in CPP_Demo is different from application to application.
So xcp.hpp and xcp.cpp should not depend on using namespace std in main.h