### PR TITLE
Fixes from integration on an embedded target

### DIFF
--- a/C_Demo/ecu.c
+++ b/C_Demo/ecu.c
@@ -130,7 +130,7 @@ uint8_t *ecuParAddrMapping( uint8_t *a ) {
 void ecuInit() {
 
     // Initialize calibration parameters
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
     ecuParInit(); // Initializes parameters in RAM calibration segment
     ecuParSetCalPage(0); // Switch to RAM calibration segment 
 #endif
@@ -155,7 +155,7 @@ void ecuInit() {
 void ecuCreateA2lDescription() {
 
     // Calibration Memory Segment
-#ifdef OPTION_ENABLE_CAL_SEGMENT  
+#if OPTION_ENABLE_CAL_SEGMENT  
     A2lCreate_MOD_PAR(ApplXcpGetAddr((uint8_t*)&ecuPar), sizeof(ecuPar), (char*)ecuPar.epk);
 #endif
 

--- a/C_Demo/main_cfg.h
+++ b/C_Demo/main_cfg.h
@@ -39,7 +39,7 @@
 #define OPTION_ENABLE_XLAPI_V3 OFF 
 #if OPTION_ENABLE_XLAPI_V3
 
-#define OPTION_USE_XLAPI_V3  // Use XL_API by default
+#define OPTION_USE_XLAPI_V3 ON // Use XL_API by default
 #define OPTION_SERVER_XL_ADDR {192,168,0,200} // XL_API Ethernet Adapter IP
 #define OPTION_SERVER_XL_MAC {0xdc,0xa6,0x32,0x7e,0x66,0xdc} // XL_API Ethernet Adapter MAC
 #define OPTION_SERVER_XL_NET "NET1" // XL_API Network name

--- a/C_Demo/xcp_cfg.h
+++ b/C_Demo/xcp_cfg.h
@@ -45,7 +45,7 @@
 //#define XCP_ENABLE_INTERLEAVED
 //#define XCP_INTERLEAVED_QUEUE_SIZE 16
 
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 #define XCP_ENABLE_CHECKSUM // Enable checksum calculation command
 #define XCP_ENABLE_CAL_PAGE // Enable cal page switch
 #endif

--- a/src/A2L.c
+++ b/src/A2L.c
@@ -49,7 +49,7 @@ static const char* gA2lHeader =
 "\n";
 
 //----------------------------------------------------------------------------------
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 static const char* gA2lMemorySegment =
 "/begin MEMORY_SEGMENT\n"
 "CALRAM \"\" DATA FLASH INTERN 0x%08X 0x%08X - 1 - 1 - 1 - 1 - 1\n" // CALRAM_START, CALRAM_SIZE
@@ -246,7 +246,7 @@ BOOL A2lOpen(const char *filename, const char* projectName ) {
 }
 
 // Memory segments
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 void A2lCreate_MOD_PAR(uint32_t startAddr, uint32_t size, char *epk) {
 	fprintf(gA2lFile, "/begin MOD_PAR \"\"\n");
 	fprintf(gA2lFile, "EPK \"%s\"\n", epk);

--- a/src/A2L.cpp
+++ b/src/A2L.cpp
@@ -46,7 +46,7 @@ static const char* sHeader =
 
 
 //----------------------------------------------------------------------------------
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 static const char* sModPar = 
 "/begin MOD_PAR \"\"\n"
 "/begin MEMORY_SEGMENT\n"
@@ -297,7 +297,7 @@ BOOL A2L::open(const char *projectName) {
 }
 
 // Create memory segments
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 void A2L::create_MOD_PAR(uint32_t startAddr, uint32_t size) {
 	fprintf(file, sModPar, startAddr, size);
 }

--- a/src/A2L.h
+++ b/src/A2L.h
@@ -74,7 +74,7 @@
 extern BOOL A2lOpen(const char *filename, const char* projectName);
 
 // Create memory segments
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 extern void A2lCreate_MOD_PAR( uint32_t startAddr, uint32_t size, char* epk);
 #endif
 

--- a/src/A2L.hpp
+++ b/src/A2L.hpp
@@ -94,7 +94,7 @@ public:
     BOOL open(const char* projectName);
     
     // Create memory segments
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
     void create_MOD_PAR(uint32_t startAddr, uint32_t size);
 #endif
 

--- a/src/platform.c
+++ b/src/platform.c
@@ -149,7 +149,7 @@ void mutexDestroy(MUTEX* m) {
     pthread_mutex_destroy(m);
 }
 
-#else
+#elif defined(_WIN)
 
 void mutexInit(MUTEX* m, int recursive, uint32_t spinCount) {
     (void) recursive;
@@ -767,7 +767,7 @@ uint64_t clockGet64() {
 #endif
 }
 
-#else // Windows
+#elif defined(_WIN) // Windows
 
 // Performance counter to clock conversion
 static uint64_t sFactor = 0; // ticks per us

--- a/src/platform.h
+++ b/src/platform.h
@@ -50,7 +50,7 @@ extern void sleepMs(uint32_t ms);
 #define mutexLock pthread_mutex_lock
 #define mutexUnlock pthread_mutex_unlock
 
-#else
+#elif defined (_WIN)
 
 #define MUTEX CRITICAL_SECTION
 #define mutexLock EnterCriticalSection
@@ -72,7 +72,7 @@ typedef HANDLE tXcpThread;
 #define join_thread(h) WaitForSingleObject(h, INFINITE);
 #define cancel_thread(h) { TerminateThread(h,0); WaitForSingleObject(h,1000); CloseHandle(h); }
 
-#else
+#elif defined(_LINUX)
 
 typedef pthread_t tXcpThread;
 #define create_thread(h,t) pthread_create(h, NULL, t, NULL);

--- a/src/util.c
+++ b/src/util.c
@@ -14,7 +14,7 @@
 #include "util.h"
 
 
-
+#ifdef XCP_ENABLE_IDT_A2L_UPLOAD
 /**************************************************************************/
 // load file to memory
 /**************************************************************************/
@@ -76,7 +76,7 @@ uint8_t* loadFile(const char* filename, uint32_t* length) {
     *length = fileLen;
     return fileBuf;
 }
-
+#endif
 
 
 
@@ -110,6 +110,7 @@ char gOptionPCAP_File[FILENAME_MAX] = APP_NAME ".pcap";
 #endif
 
 
+#if defined(_WIN) || defined(_LINUX)
 /**************************************************************************/
 // cmd line parser
 /**************************************************************************/
@@ -125,7 +126,7 @@ void cmdline_usage(const char* appName) {
         "    -dx              Set output verbosity to x (default is 1)\n"
         "    -bind <ipaddr>   IP address to bind (default is ANY (0.0.0.0))\n"
         "    -port <portname> Server port (default is 5555)\n"
-#ifdef OPTION_ENABLE_TCP
+#if OPTION_ENABLE_TCP
 #if OPTION_USE_TCP
         "    -udp             Use UDP\n"
 #else
@@ -187,7 +188,7 @@ BOOL cmdline_parser(int argc, char* argv[]) {
                 }
             }
         }
-#ifdef OPTION_ENABLE_TCP
+#if OPTION_ENABLE_TCP
         else if (strcmp(argv[i], "-tcp") == 0) {
             gOptionUseTCP = TRUE;
         }
@@ -253,7 +254,7 @@ BOOL cmdline_parser(int argc, char* argv[]) {
 
     if (gDebugLevel) printf("Set screen output verbosity to %u\n", gDebugLevel);
 
-#ifdef OPTION_ENABLE_TCP
+#if OPTION_ENABLE_TCP
     printf("Using %s\n", gOptionUseTCP ? "TCP" : "UDP");
 #endif
 #if OPTION_ENABLE_XLAPI_V3
@@ -264,3 +265,4 @@ BOOL cmdline_parser(int argc, char* argv[]) {
     return TRUE;
 }
 
+#endif

--- a/src/xcp.hpp
+++ b/src/xcp.hpp
@@ -9,7 +9,7 @@
 #include "xcptl_cfg.h" // Transport Layer configuration
 #include "xcp_cfg.h" // Protocoll Layer configuration
 
-#ifdef OPTION_ENABLE_A2L_GEN
+#if OPTION_ENABLE_A2L_GEN
 #include "A2L.hpp" // A2L generator
 #endif
 
@@ -24,7 +24,7 @@ private:
 	const uint8_t* addr;
 	uint16_t port;
 
-#ifdef OPTION_ENABLE_A2L_GEN
+#if OPTION_ENABLE_A2L_GEN
 	A2L* a2lFile;
 #endif	
 
@@ -98,7 +98,7 @@ public:
 	const char* getA2lFileName(); // Get A2L filename info for GET_ID name and upload 
 
 	// Optional: A2L generation
-#ifdef OPTION_ENABLE_A2L_GEN
+#if OPTION_ENABLE_A2L_GEN
 	A2L* createA2L(const char* projectName); 
     A2L* getA2L() { return a2lFile; }
 	void closeA2L();
@@ -119,8 +119,10 @@ private:
 protected:
 	const char* instanceName;
 
+#if OPTION_ENABLE_A2L_GEN
 	// Create components (A2L STRUCTURE_COMPONENTS) components of inheriting classes
 	virtual void a2lCreateTypedefComponents(A2L* a2l) { (void)a2l; };
+#endif
 
 public:
 

--- a/src/xcpAppl.c
+++ b/src/xcpAppl.c
@@ -20,7 +20,7 @@
 #ifdef APP_CPP_Demo
 #include "xcp.hpp"
 #else
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 #include "ecu.h"
 #endif
 #endif
@@ -367,7 +367,7 @@ void ApplXcpInitBaseAddressList()
 // Calibration page handling
 /**************************************************************************/
 
-#ifdef OPTION_ENABLE_CAL_SEGMENT
+#if OPTION_ENABLE_CAL_SEGMENT
 
 // segment = 0
 // RAM = page 0, FLASH = page 1


### PR DESCRIPTION
These are some changes I did when integrating this library on an embedded target - they were needed because of compilation errors after I turned off a few options to reduce the code size.