### PR TITLE
Use XCPlite in an ECU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 build_C_Demo/
 build_CPP_Demo/
+build_Use_in_ECU_Demo/
 bin/
 obj/
 *.[oa]

--- a/Use_in_ECU/CMakeLists.txt
+++ b/Use_in_ECU/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+project(Use_in_ECU VERSION 5.0 LANGUAGES C)
+set(WINDOWS FALSE)
+
+set(CMAKE_C_COMPILER "gcc")
+set(CMAKE_CXX_COMPILER "g++")
+
+set(Use_in_ECU_WIN_SOURCES 
+  main.c ecu.c 
+  ../src/xcpAppl.c ../src/xcpLite.c ../src/xcpTl.c ../src/xcpServer.c ../src/A2L.c ../src/platform.c ../src/util.c 
+  ../xlapi/xl_udp.c ../xlapi/xl_pcap.c
+)
+set_source_files_properties(${Use_in_ECU_WIN_SOURCES} PROPERTIES LANGUAGE C)
+
+set(Use_in_ECU_LINUX_SOURCES 
+  main.c 
+  ../src/xcpLite.c ./xcpTl.c
+)
+set_source_files_properties(${Use_in_ECU_LINUX_SOURCES} PROPERTIES LANGUAGE C)
+
+set(OPTION_DEBUG_LEVEL 2 CACHE STRING "Debug output level")
+option(OPTION_ENABLE_TCP "Enable TCP" 1)
+option(OPTION_USE_TCP "Use TCP by default" 0)
+set(OPTION_SERVER_PORT 5555 CACHE STRING "XCP default port")
+set(OPTION_SERVER_ADDR {0,0,0,0} CACHE STRING "XCP IP address to bind, ANY=0.0.0.0")
+option(OPTION_ENABLE_A2L_GEN "Enable A2L file generator" 1)
+option(OPTION_ENABLE_CAL_SEGMENT "" 1)
+option(OPTION_ENABLE_XLAPI_V3 "" 0)
+set(OPTION_SERVER_XL_ADDR {192,168,0,200} CACHE STRING "")
+set(OPTION_SERVER_XL_MAC {0xdc,0xa6,0x32,0x7e,0x66,0xdc} CACHE STRING "")
+set(OPTION_SERVER_XL_NET "NET1" CACHE STRING "")
+set(OPTION_SERVER_XL_SEG "SEG1" CACHE STRING "")
+
+if (WINDOWS)
+add_executable(Use_in_ECU ${Use_in_ECU_WIN_SOURCES})
+set(OPTION_USE_XLAPI_V3 ON)
+else ()
+add_executable(Use_in_ECU ${Use_in_ECU_LINUX_SOURCES})
+endif ()
+
+configure_file(main_cfg.h.in ${PROJECT_SOURCE_DIR}/main_cfg.h)
+
+target_include_directories(Use_in_ECU PUBLIC "${PROJECT_SOURCE_DIR}" )
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
+
+if (WINDOWS)
+else ()
+#set_target_properties(Use_in_ECU PROPERTIES OUTPUT_NAME "Use_in_ECU.out")
+set_target_properties(Use_in_ECU PROPERTIES SUFFIX ".out")
+target_link_libraries(${PROJECT_NAME} PRIVATE m)
+endif ()

--- a/Use_in_ECU/main.c
+++ b/Use_in_ECU/main.c
@@ -1,0 +1,163 @@
+/*----------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "xcpLite.h"
+/*----------------------------------------------------------------------------*/
+#define CAST( am_Type, am_Value )    ( ( am_Type )( am_Value ) )
+/*----------------------------------------------------------------------------*/
+uint8_t const APPL_MEMORY[ 4 ] = { 0x03, 0x05, 0x00, 0x06 };
+/*----------------------------------------------------------------------------*/
+uint8_t* ApplXcpGetPointer(uint8_t addr_ext, uint32_t addr)
+{
+  /* tell XCP the memory pointer to ext,addr */
+  /* return NULL to tell XCP access denied */
+  /* return CAST( uint8_t *, addr ) for normal situations */
+  return CAST( uint8_t *, ( addr != 0x01020304 ? NULL : APPL_MEMORY ) );
+}
+/*----------------------------------------------------------------------------*/
+uint64_t ApplXcpGetClock64()
+{
+  return 0;
+}
+/*----------------------------------------------------------------------------*/
+uint8_t *ApplXcpGetBaseAddr()
+{
+  return NULL;
+}
+/*----------------------------------------------------------------------------*/
+BOOL ApplXcpConnect()
+{
+  // tell XCP that we accept the connection
+  return TRUE;
+}
+/*----------------------------------------------------------------------------*/
+BOOL ApplXcpPrepareDaq()
+{
+}
+/*----------------------------------------------------------------------------*/
+BOOL ApplXcpStartDaq()
+{
+}
+/*----------------------------------------------------------------------------*/
+void ApplXcpStopDaq()
+{
+}
+/*----------------------------------------------------------------------------*/
+uint8_t ApplXcpGetClockState()
+{
+  return 0;
+}
+/*----------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+struct tCanMsg
+{
+  uint8_t  t_Dlc;
+  uint8_t  t_Data[ 8 ];
+};
+typedef struct tCanMsg  tCanMsg;
+/*----------------------------------------------------------------------------*/
+/* CAN messages sent by TESTER to ECU */
+tCanMsg const XCP_CAN_CONNECT =        { 2, {                   CC_CONNECT, 0, 0 ,0,  0, 0, 0, 0 } };
+tCanMsg const XCP_CAN_DISCONNECT =     { 2, {                CC_DISCONNECT, 0, 0 ,0,  0, 0, 0, 0 } };
+
+/* addr_ext (byte 3) = 0 (standard memory access), addr = 0x1234 */
+tCanMsg const XCP_CAN_SHORT_UPLOAD =       { 8, {         CC_SHORT_UPLOAD, 2, 0 , 0,  4, 3, 2, 1 } };
+
+/* daq_count = byte 2,3 = 2 */
+tCanMsg const XCP_CAN_ALLOQ_DAQ =             { 4, {            CC_ALLOC_DAQ, 0, 2 , 0,  0, 0, 0, 0 } };
+/* daq_list = byte 2,3 = 1,  odt_count = byte 4 = 3 */
+tCanMsg const XCP_CAN_ALLOQ_ODT =             { 5, {            CC_ALLOC_ODT, 0, 1 , 0,  3, 0, 0, 0 } };
+/* daq_list = byte 2,3 = 1,  odt_num = byte 4 = 2, odt_count = byte 5 = 2 */
+tCanMsg const XCP_CAN_ALLOQ_ODTENTRY =        { 6, {      CC_ALLOC_ODT_ENTRY, 0, 1 , 0,  2, 2, 0, 0 } };
+
+/* daq_list = byte 2,3 = 1,  odt_num = byte 4 = 2, odt_count = byte 5 = 3 */
+tCanMsg const XCP_CAN_SET_DAQ_PTR_0 =         { 6, {          CC_SET_DAQ_PTR, 0, 1 , 0,  2, 0, 0, 0 } };
+/* bit_offset = byte 1 = 0, size = byte 2 = 1, addr_ext = byte 3 = 0, addr = byte 4..7 = 0x01020304 */
+tCanMsg const XCP_CAN_WRITE_DAQ_0 =           { 8, {            CC_WRITE_DAQ, 0, 1 , 0,  4, 3, 2, 1 } };
+/* bit_offset = byte 1 = 0, size = byte 2 = 2, addr_ext = byte 3 = 0, addr = byte 4..7 = 0x01020304 */
+tCanMsg const XCP_CAN_WRITE_DAQ_1 =           { 8, {            CC_WRITE_DAQ, 0, 2 , 0,  4, 3, 2, 1 } };
+/* bit_offset = byte 1 = 0, size = byte 2 = 4, addr_ext = byte 3 = 0, addr = byte 4..7 = 0x01020304 */
+tCanMsg const XCP_CAN_WRITE_DAQ_2 =           { 8, {            CC_WRITE_DAQ, 0, 4 , 0,  4, 3, 2, 1 } };
+/* mode = byte 1 = 1 = start, daq_list = byte 2,3 = 0 */
+tCanMsg const XCP_CAN_START_STOP_DAQ_LIST_0 = { 4, {  CC_START_STOP_DAQ_LIST, 1, 0 , 0,  0, 0, 0, 0 } };
+/* mode = byte 1 = 1 = start, daq_list = byte 2,3 = 1 */
+tCanMsg const XCP_CAN_START_STOP_DAQ_LIST_1 = { 4, {  CC_START_STOP_DAQ_LIST, 1, 1 , 0,  0, 0, 0, 0 } };
+/* mode = byte 1, daq_list = byte 2,3, event = byte 4,5, prescale = byte 6, prio = byte 7 */
+tCanMsg const
+XCP_CAN_SET_DAQ_LIST_MODE_0 =
+{
+  8,
+  {
+    CC_SET_DAQ_LIST_MODE,  /* PID */
+    DAQ_FLAG_TIMESTAMP,    /* mode */
+    0, 0,                  /* daq_list */
+    0, 0,                  /* event = l_Event10ms */
+    1,                     /* prescale */
+    7                      /* prio */
+  }
+};
+tCanMsg const
+XCP_CAN_SET_DAQ_LIST_MODE_1 =
+{
+  8,
+  {
+    CC_SET_DAQ_LIST_MODE,  /* PID */
+    DAQ_FLAG_TIMESTAMP,    /* mode */
+    1, 0,                  /* daq_list */
+    0, 0,                  /* event = l_Event10ms */
+    1,                     /* prescale */
+    7                      /* prio */
+  }
+};
+
+/*----------------------------------------------------------------------------*/
+int
+main( int argc, char *argv[] )
+{
+  uint16_t  l_Event10ms;
+
+  printf( "/* ECU setup */\n" );
+  XcpInit();
+  XcpTlInit();
+  XcpStart();
+
+  printf( "/* ECU has one XCP event */\n" );
+  l_Event10ms = XcpCreateEvent( "10ms", 10000000, 1, 0, 1 );
+
+  printf( "/* ECU receives CONNECT, SHORT UPLOAD */\n" );
+  XcpTlCanReceive( XCP_CAN_CONNECT.t_Data, XCP_CAN_CONNECT.t_Dlc );
+  XcpTlCanReceive( XCP_CAN_SHORT_UPLOAD.t_Data, XCP_CAN_SHORT_UPLOAD.t_Dlc );
+
+  printf( "/* ECU receives DAQ configuration */\n" );
+  /*
+    DAQ 0  ->  nothing
+    DAQ 1  ->  ODT 0  ->  nothing
+           ->  ODT 1  ->  nothing
+           ->  ODT 2  ->  ODT_ENTRY 1 = siz,ext,addr = 2,0,0x01020304
+                      ->  ODT_ENTRY 2 = siz,ext,addr = 4,0,0x01020304
+  */
+  XcpTlCanReceive( XCP_CAN_ALLOQ_DAQ.t_Data, XCP_CAN_ALLOQ_DAQ.t_Dlc );
+  XcpTlCanReceive( XCP_CAN_ALLOQ_ODT.t_Data, XCP_CAN_ALLOQ_ODT.t_Dlc );
+  XcpTlCanReceive( XCP_CAN_ALLOQ_ODTENTRY.t_Data, XCP_CAN_ALLOQ_ODTENTRY.t_Dlc );
+  /* SET_DAQ_PTR to ODT_ENTRY 0 */
+  XcpTlCanReceive( XCP_CAN_SET_DAQ_PTR_0.t_Data, XCP_CAN_SET_DAQ_PTR_0.t_Dlc );
+  /* fill the pointed-to ODT_ENTRY */
+  XcpTlCanReceive( XCP_CAN_WRITE_DAQ_1.t_Data, XCP_CAN_WRITE_DAQ_1.t_Dlc );
+  /* SET_DAQ_PTR auto increments to next ODT_ENTRY */
+  XcpTlCanReceive( XCP_CAN_WRITE_DAQ_2.t_Data, XCP_CAN_WRITE_DAQ_2.t_Dlc );
+  /* tell DAQ 0 that it must be active at event 0 */
+  XcpTlCanReceive( XCP_CAN_SET_DAQ_LIST_MODE_0.t_Data, XCP_CAN_SET_DAQ_LIST_MODE_0.t_Dlc );
+  /* tell DAQ 1 that it must be active at event 0 */
+  XcpTlCanReceive( XCP_CAN_SET_DAQ_LIST_MODE_1.t_Data, XCP_CAN_SET_DAQ_LIST_MODE_1.t_Dlc );
+  printf( "/* start DAQ's, then TESTER waits until event occurs in ECU */\n" );
+  XcpTlCanReceive( XCP_CAN_START_STOP_DAQ_LIST_0.t_Data, XCP_CAN_START_STOP_DAQ_LIST_0.t_Dlc );
+  XcpTlCanReceive( XCP_CAN_START_STOP_DAQ_LIST_1.t_Data, XCP_CAN_START_STOP_DAQ_LIST_1.t_Dlc );
+
+  printf( "/* ECU signals another 10ms loop passage */\n" );
+  XcpEvent( l_Event10ms );
+  XcpTlTransmitThreadCycle();
+
+  printf( "/* ECU receives DISCONNECT */\n" );
+  XcpTlCanReceive( XCP_CAN_DISCONNECT.t_Data, XCP_CAN_DISCONNECT.t_Dlc );
+
+  return 0;
+}/*----------------------------------------------------------------------------*/

--- a/Use_in_ECU/main.h
+++ b/Use_in_ECU/main.h
@@ -1,0 +1,92 @@
+#pragma once
+
+/* main.h */
+/*
+| Code released into public domain, no attribution required
+*/
+
+// Windows or Linux ?
+#if defined(_WIN32) || defined(_WIN64)
+  #define _WIN
+  #if defined(_WIN32) && defined(_WIN64)
+    #undef _WIN32
+  #endif
+  #if defined(_LINUX) || defined(_LINUX64)|| defined(_LINUX32)
+    #error
+  #endif
+#else
+  #define _LINUX
+  #if defined (_ix64_) || defined (__x86_64__) || defined (__aarch64__)
+    #define _LINUX64
+  #else
+    #define _LINUX32
+  #endif
+  #if defined(_WIN) || defined(_WIN64)|| defined(_WIN32)
+    #error
+  #endif
+#endif
+
+
+#ifdef _WIN
+  #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+  #endif
+  #ifndef _CRT_SECURE_NO_WARNINGS
+    #define _CRT_SECURE_NO_WARNINGS
+  #endif
+#else
+  #ifndef _DEFAULT_SOURCE
+    #define _DEFAULT_SOURCE
+  #endif
+#endif
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <math.h>
+
+#ifdef _WIN
+#define M_PI 3.14159265358979323846
+#endif
+#define M_2PI (M_PI*2)
+
+#include <assert.h>
+
+#ifndef _WIN // Linux
+
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include <sys/time.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <pthread.h>
+
+#include <ifaddrs.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+#define MAX_PATH 256
+#define BOOL int
+#define FALSE 0
+#define TRUE 1
+
+#else // Windows
+
+#include <windows.h>
+#include <time.h>
+#include <conio.h>
+
+#define BOOL int
+#define FALSE 0
+#define TRUE 1
+
+#endif
+

--- a/Use_in_ECU/main_cfg.h
+++ b/Use_in_ECU/main_cfg.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// main_cfg.h.in
+// C_Demo
+
+/* Copyright(c) Vector Informatik GmbH.All rights reserved.
+   Licensed under the MIT license.See LICENSE file in the project root for details. */
+
+
+#define APP_NAME "C_Demo"
+#define APP_VERSION_MAJOR 
+#define APP_VERSION_MINOR 
+
+
+//-----------------------------------------------------------------------------------------------------
+// Application configuration:
+// XCP configuration is in xcp_cfg.h (Protocol Layer) and xcptl_cfg.h (Transport Layer)
+
+#define ON 1
+#define OFF 0
+
+#define OPTION_DEBUG_LEVEL 2 
+
+// A2L generation
+#define OPTION_ENABLE_A2L_GEN ON // Enable A2L generation
+#define OPTION_A2L_FILE_NAME APP_NAME ".a2l" // A2L full filename (with path)
+#define OPTION_A2L_PROJECT_NAME "Demo" // A2L project name
+
+// Default ip addr and port
+#define OPTION_ENABLE_TCP ON // Enable TCP support and commandline option -tcp
+#define OPTION_USE_TCP OFF // Enable TCP by default and commandline option -udp
+#define OPTION_SERVER_PORT 5555 // Default UDP port, overwritten by commandline option -port
+#define OPTION_SERVER_ADDR {0,0,0,0} // Default IP addr, 0.0.0.0 = ANY, 255.255.255.255 = first adapter found, overwritten by commandline option -bind x.x.x.x
+
+// Calibration segment
+#define OPTION_ENABLE_CAL_SEGMENT ON
+
+#ifdef _WIN
+#define OPTION_ENABLE_XLAPI_V3 OFF 
+#if OPTION_ENABLE_XLAPI_V3
+
+#define OPTION_USE_XLAPI_V3  // Use XL-API by default
+#define OPTION_SERVER_XL_ADDR {192,168,0,200} // XL_API Ethernet Adapter IP
+#define OPTION_SERVER_XL_MAC {0xdc,0xa6,0x32,0x7e,0x66,0xdc} // XL_API Ethernet Adapter MAC
+#define OPTION_SERVER_XL_NET "NET1" // XL_API Network name
+#define OPTION_SERVER_XL_SEG "SEG1" // XL_API Segment name
+
+#endif
+#endif
+

--- a/Use_in_ECU/main_cfg.h.in
+++ b/Use_in_ECU/main_cfg.h.in
@@ -1,0 +1,50 @@
+#pragma once
+
+// main_cfg.h.in
+// C_Demo
+
+/* Copyright(c) Vector Informatik GmbH.All rights reserved.
+   Licensed under the MIT license.See LICENSE file in the project root for details. */
+
+
+#define APP_NAME "C_Demo"
+#define APP_VERSION_MAJOR @C_Demo_VERSION_MAJOR@
+#define APP_VERSION_MINOR @C_Demo_VERSION_MINOR@
+
+
+//-----------------------------------------------------------------------------------------------------
+// Application configuration:
+// XCP configuration is in xcp_cfg.h (Protocol Layer) and xcptl_cfg.h (Transport Layer)
+
+#define ON 1
+#define OFF 0
+
+#define OPTION_DEBUG_LEVEL @OPTION_DEBUG_LEVEL@ 
+
+// A2L generation
+#define OPTION_ENABLE_A2L_GEN @OPTION_ENABLE_A2L_GEN@ // Enable A2L generation
+#define OPTION_A2L_FILE_NAME APP_NAME ".a2l" // A2L full filename (with path)
+#define OPTION_A2L_PROJECT_NAME "Demo" // A2L project name
+
+// Default ip addr and port
+#define OPTION_ENABLE_TCP @OPTION_ENABLE_TCP@ // Enable TCP support and commandline option -tcp
+#define OPTION_USE_TCP @OPTION_USE_TCP@ // Enable TCP by default and commandline option -udp
+#define OPTION_SERVER_PORT @OPTION_SERVER_PORT@ // Default UDP port, overwritten by commandline option -port
+#define OPTION_SERVER_ADDR @OPTION_SERVER_ADDR@ // Default IP addr, 0.0.0.0 = ANY, 255.255.255.255 = first adapter found, overwritten by commandline option -bind x.x.x.x
+
+// Calibration segment
+#define OPTION_ENABLE_CAL_SEGMENT @OPTION_ENABLE_CAL_SEGMENT@
+
+#ifdef _WIN
+#define OPTION_ENABLE_XLAPI_V3 @OPTION_ENABLE_XLAPI_V3@ 
+#if OPTION_ENABLE_XLAPI_V3
+
+#define OPTION_USE_XLAPI_V3 @OPTION_USE_XLAPI_V3@ // Use XL-API by default
+#define OPTION_SERVER_XL_ADDR @OPTION_SERVER_XL_ADDR@ // XL_API Ethernet Adapter IP
+#define OPTION_SERVER_XL_MAC @OPTION_SERVER_XL_MAC@ // XL_API Ethernet Adapter MAC
+#define OPTION_SERVER_XL_NET "@OPTION_SERVER_XL_NET@" // XL_API Network name
+#define OPTION_SERVER_XL_SEG "@OPTION_SERVER_XL_SEG@" // XL_API Segment name
+
+#endif
+#endif
+

--- a/Use_in_ECU/xcp.h
+++ b/Use_in_ECU/xcp.h
@@ -1,0 +1,1197 @@
+#pragma once
+
+/* xcp.h */
+#include <stdint.h>
+#include "xcp_cfg.h"
+
+/* Copyright(c) Vector Informatik GmbH.All rights reserved.
+   Licensed under the MIT license.See LICENSE file in the project root for details. */
+
+
+/***************************************************************************/
+/* Commands                                                                */
+/***************************************************************************/
+
+/*-------------------------------------------------------------------------*/
+/* Standard Commands */
+
+#define CC_CONNECT                        0xFF
+#define CC_DISCONNECT                     0xFE
+#define CC_GET_STATUS                     0xFD
+#define CC_SYNC                           0xFC
+
+#define CC_GET_COMM_MODE_INFO             0xFB
+#define CC_GET_ID                         0xFA
+#define CC_SET_REQUEST                    0xF9
+#define CC_GET_SEED                       0xF8
+#define CC_UNLOCK                         0xF7
+#define CC_SET_MTA                        0xF6
+#define CC_UPLOAD                         0xF5
+#define CC_SHORT_UPLOAD                   0xF4
+#define CC_BUILD_CHECKSUM                 0xF3
+
+#define CC_TRANSPORT_LAYER_CMD            0xF2
+#define CC_USER_CMD                       0xF1
+
+
+/*-------------------------------------------------------------------------*/
+/* Calibration Commands*/
+
+#define CC_DOWNLOAD                       0xF0
+
+#define CC_DOWNLOAD_NEXT                  0xEF
+#define CC_DOWNLOAD_MAX                   0xEE
+#define CC_SHORT_DOWNLOAD                 0xED
+#define CC_MODIFY_BITS                    0xEC
+
+
+/*-------------------------------------------------------------------------*/
+/* Page switching Commands (PAG) */
+
+#define CC_SET_CAL_PAGE                   0xEB
+#define CC_GET_CAL_PAGE                   0xEA
+
+#define CC_GET_PAG_PROCESSOR_INFO         0xE9
+#define CC_GET_SEGMENT_INFO               0xE8
+#define CC_GET_PAGE_INFO                  0xE7
+#define CC_SET_SEGMENT_MODE               0xE6
+#define CC_GET_SEGMENT_MODE               0xE5
+#define CC_COPY_CAL_PAGE                  0xE4
+
+
+/*-------------------------------------------------------------------------*/
+/* Data acquisition and Stimulation Commands (DAQ/STIM) */
+
+#define CC_CLEAR_DAQ_LIST                 0xE3
+#define CC_SET_DAQ_PTR                    0xE2
+#define CC_WRITE_DAQ                      0xE1
+#define CC_SET_DAQ_LIST_MODE              0xE0
+#define CC_GET_DAQ_LIST_MODE              0xDF
+#define CC_START_STOP_DAQ_LIST            0xDE
+#define CC_START_STOP_SYNCH               0xDD
+
+#define CC_GET_DAQ_CLOCK                  0xDC
+#define CC_READ_DAQ                       0xDB
+#define CC_GET_DAQ_PROCESSOR_INFO         0xDA
+#define CC_GET_DAQ_RESOLUTION_INFO        0xD9
+#define CC_GET_DAQ_LIST_INFO              0xD8
+#define CC_GET_DAQ_EVENT_INFO             0xD7
+
+#define CC_FREE_DAQ                       0xD6
+#define CC_ALLOC_DAQ                      0xD5
+#define CC_ALLOC_ODT                      0xD4
+#define CC_ALLOC_ODT_ENTRY                0xD3
+
+
+/*-------------------------------------------------------------------------*/
+/* Non volatile memory Programming Commands PGM */
+
+#define CC_PROGRAM_START                  0xD2
+#define CC_PROGRAM_CLEAR                  0xD1
+#define CC_PROGRAM                        0xD0
+#define CC_PROGRAM_RESET                  0xCF
+#define CC_GET_PGM_PROCESSOR_INFO         0xCE
+#define CC_GET_SECTOR_INFO                0xCD
+#define CC_PROGRAM_PREPARE                0xCC
+#define CC_PROGRAM_FORMAT                 0xCB
+#define CC_PROGRAM_NEXT                   0xCA
+#define CC_PROGRAM_MAX                    0xC9
+#define CC_PROGRAM_VERIFY                 0xC8
+
+/*-------------------------------------------------------------------------*/
+/* XCP >= V1.1 Commands */
+# define CC_WRITE_DAQ_MULTIPLE            0xC7 /* XCP V1.1 specific commands */
+
+/*-------------------------------------------------------------------------*/
+/* XCP >= V1.3 Commands */
+#if XCP_PROTOCOL_LAYER_VERSION >= 0x0103
+# define CC_TIME_CORRELATION_PROPERTIES   0xC6 /* XCP V1.3 specific commands */
+#endif
+
+/*-------------------------------------------------------------------------*/
+/* XCP >= V1.4 Commands */
+#if XCP_PROTOCOL_LAYER_VERSION >= 0x0104
+#define CC_LEVEL_1_COMMAND                0xC0 /* XCP V1.4 Level 1 Commands: */
+#define CC_GET_VERSION                    0x00
+#define CC_SET_DAQ_LIST_PACKED_MODE       0x01
+#define CC_GET_DAQ_LIST_PACKED_MODE       0x02
+#define CC_SW_DBG_OVER_XCP                0xFC
+#endif
+
+/*-------------------------------------------------------------------------*/
+/* Packet Identifiers Server -> Master */
+#define PID_RES                           0xFF   /* response packet        */
+#define PID_ERR                           0xFE   /* error packet           */
+#define PID_EV                            0xFD   /* event packet           */
+#define PID_SERV                          0xFC   /* service request packet */
+
+
+/*-------------------------------------------------------------------------*/
+/* Command Return Codes */
+
+#define CRC_CMD_SYNCH                           0x00
+#define CRC_CMD_PENDING                         0x01
+#define CRC_CMD_BUSY                            0x10
+#define CRC_DAQ_ACTIVE                          0x11
+#define CRC_PRM_ACTIVE                          0x12
+#define CRC_CMD_UNKNOWN                         0x20
+#define CRC_CMD_SYNTAX                          0x21
+#define CRC_OUT_OF_RANGE                        0x22
+#define CRC_WRITE_PROTECTED                     0x23
+#define CRC_ACCESS_DENIED                       0x24
+#define CRC_ACCESS_LOCKED                       0x25
+#define CRC_PAGE_NOT_VALID                      0x26
+#define CRC_PAGE_MODE_NOT_VALID                 0x27
+#define CRC_SEGMENT_NOT_VALID                   0x28
+#define CRC_SEQUENCE                            0x29
+#define CRC_DAQ_CONFIG                          0x2A
+#define CRC_MEMORY_OVERFLOW                     0x30
+#define CRC_GENERIC                             0x31
+#define CRC_VERIFY                              0x32
+#define CRC_RESOURCE_TEMPORARY_NOT_ACCESSIBLE   0x33
+#define CRC_SUBCMD_UNKNOWN                      0x34
+#define CRC_TIMECORR_STATE_CHANGE               0x35
+
+
+/*-------------------------------------------------------------------------*/
+/* Event Codes */
+
+#define EVC_RESUME_MODE        0x00
+#define EVC_CLEAR_DAQ          0x01
+#define EVC_STORE_DAQ          0x02
+#define EVC_STORE_CAL          0x03
+#define EVC_CMD_PENDING        0x05
+#define EVC_DAQ_OVERLOAD       0x06
+#define EVC_SESSION_TERMINATED 0x07
+#define EVC_TIME_SYNC          0x08
+#define EVC_STIM_TIMEOUT       0x09
+#define EVC_SLEEP              0x0A
+#define EVC_WAKEUP             0x0B
+#define EVC_ECU_STATE          0x0C
+#define EVC_USER               0xFE
+#define EVC_TRANSPORT          0xFF
+
+
+/*-------------------------------------------------------------------------*/
+/* Service Request Codes */
+
+#define SERV_RESET                            0x00 /* Server requesting to be reset */
+#define SERV_TEXT                             0x01 /* Plain ASCII text null terminated */
+
+
+
+
+/***************************************************************************/
+/* Definitions                                                             */
+/***************************************************************************/
+
+/*-------------------------------------------------------------------------*/
+/* ResourceMask (CONNECT) */
+
+#define RM_CAL_PAG                  0x01
+#define RM_DAQ                      0x04
+#define RM_STIM                     0x08
+#define RM_PGM                      0x10
+#define RM_DBG                      0x20
+
+
+/*-------------------------------------------------------------------------*/
+/* CommModeBasic (CONNECT) */
+
+#define PI_MOTOROLA                   0x01
+
+#define CMB_BYTE_ORDER                (0x01u<<0)
+#define CMB_ADDRESS_GRANULARITY       (0x03u<<1)
+#define CMB_SERVER_BLOCK_MODE          (0x01u<<6)
+#define CMB_OPTIONAL                  (0x01u<<7)
+
+#define CMB_ADDRESS_GRANULARITY_BYTE  (0<<1)
+#define CMB_ADDRESS_GRANULARITY_WORD  (1<<1)
+#define CMB_ADDRESS_GRANULARITY_DWORD (2<<1)
+#define CMB_ADDRESS_GRANULARITY_QWORD (3<<1)
+
+
+/*-------------------------------------------------------------------------*/
+/* Protocol Info (GET_COMM_MODE_INFO - COMM_OPTIONAL) */
+
+#define CMO_MASTER_BLOCK_MODE  0x01
+#define CMO_INTERLEAVED_MODE   0x02
+
+
+/*-------------------------------------------------------------------------*/
+/* Session Status (GET_STATUS and SET_REQUEST) */
+
+// XCP states (low byte) */
+#define SS_STORE_CAL_REQ       ((uint16_t)0x0001)
+#define SS_STORE_DAQ_REQ       ((uint16_t)0x0004)
+#define SS_CLEAR_DAQ_REQ       ((uint16_t)0x0008)
+#define SS_DAQ                 ((uint16_t)0x0040)
+#define SS_RESUME              ((uint16_t)0x0080)
+
+// Internal states (high byte) */
+#define SS_BLOCK_UPLOAD        ((uint16_t)0x0100) /* Block upload in progress */
+#define SS_LEGACY_MODE         ((uint16_t)0x0200) /* XCP 1.3 legacy mode */
+#define SS_CMD_PENDING         ((uint16_t)0x0800) /* async comand pending */
+#define SS_INITIALIZED         ((uint16_t)0x8000) /* initialized */
+#define SS_STARTED             ((uint16_t)0x4000) /* started*/ 
+#define SS_CONNECTED           ((uint16_t)0x2000) /* connected */
+
+
+/*-------------------------------------------------------------------------*/
+/* Identifier Type (GET_ID) */
+
+#define IDT_ASCII              0
+#define IDT_ASAM_NAME          1
+#define IDT_ASAM_PATH          2
+#define IDT_ASAM_URL           3
+#define IDT_ASAM_UPLOAD        4
+#define IDT_ASAM_EPK           5
+#define IDT_ASAM_ECU           6
+#define IDT_ASAM_SYSID         7
+
+/*-------------------------------------------------------------------------*/
+/* Checksum Types (BUILD_CHECKSUM) */
+
+#define XCP_CHECKSUM_TYPE_ADD11      0x01  /* Add BYTE into a BYTE checksum, ignore overflows */
+#define XCP_CHECKSUM_TYPE_ADD12      0x02  /* Add BYTE into a WORD checksum, ignore overflows */
+#define XCP_CHECKSUM_TYPE_ADD14      0x03  /* Add BYTE into a DWORD checksum, ignore overflows */
+#define XCP_CHECKSUM_TYPE_ADD22      0x04  /* Add WORD into a WORD checksum, ignore overflows, blocksize must be modulo 2 */
+#define XCP_CHECKSUM_TYPE_ADD24      0x05  /* Add WORD into a DWORD checksum, ignore overflows, blocksize must be modulo 2 */
+#define XCP_CHECKSUM_TYPE_ADD44      0x06  /* Add DWORD into DWORD, ignore overflows, blocksize must be modulo 4 */
+#define XCP_CHECKSUM_TYPE_CRC16      0x07  /* See CRC error detection algorithms */
+#define XCP_CHECKSUM_TYPE_CRC16CCITT 0x08  /* See CRC error detection algorithms */
+#define XCP_CHECKSUM_TYPE_CRC32      0x09  /* See CRC error detection algorithms */
+#define XCP_CHECKSUM_TYPE_DLL        0xFF  /* User defined, ASAM MCD 2MC DLL Interface */
+
+
+/*-------------------------------------------------------------------------*/
+/* Page Mode (SET_CAL_PAGE) */
+
+#define CAL_PAGE_MODE_ECU                0x01
+#define CAL_PAGE_MODE_XCP                0x02
+#define CAL_PAGE_MODE_ALL                0x80
+
+
+/*-------------------------------------------------------------------------*/
+/* PAG_PROPERTIES (GET_PAG_PROCESSOR_INFO) */
+
+#define PAG_PROPERTY_FREEZE               0x01
+
+
+/*-------------------------------------------------------------------------*/
+/* PAGE_PROPERTIES (GET_PAGE_INFO)*/
+
+#define ECU_ACCESS_TYPE                   0x03
+#define XCP_READ_ACCESS_TYPE              0x0C
+#define XCP_WRITE_ACCESS_TYPE             0x30
+
+/* ECU_ACCESS_TYPE */
+#define ECU_ACCESS_NONE                   (0<<0)
+#define ECU_ACCESS_WITHOUT                (1<<0)
+#define ECU_ACCESS_WITH                   (2<<0)
+#define ECU_ACCESS_DONT_CARE              (3<<0)
+
+/* XCP_READ_ACCESS_TYPE */
+#define XCP_READ_ACCESS_NONE              (0<<2)
+#define XCP_READ_ACCESS_WITHOUT           (1<<2)
+#define XCP_READ_ACCESS_WITH              (2<<2)
+#define XCP_READ_ACCESS_DONT_CARE         (3<<2)
+
+/* XCP_WRITE_ACCESS_TYPE */
+#define XCP_WRITE_ACCESS_NONE             (0<<4)
+#define XCP_WRITE_ACCESS_WITHOUT          (1<<4)
+#define XCP_WRITE_ACCESS_WITH             (2<<4)
+#define XCP_WRITE_ACCESS_DONT_CARE        (3<<4)
+
+
+/*-------------------------------------------------------------------------*/
+/* SEGMENT_MODE (GET_SEGMENT_MODE, SET_SEGMENT_MODE) */
+
+#define SEGMENT_FLAG_FREEZE               0x01 /* */
+
+
+/*-------------------------------------------------------------------------*/
+/* DAQ_LIST_MODE (GET_DAQ_LIST_MODE, SET_DAQ_LIST_MODE) */
+
+#define DAQ_FLAG_SELECTED                 ((uint8_t)0x01) /* */
+#define DAQ_FLAG_DIRECTION                ((uint8_t)0x02) /* Data Stimulation Mode */
+#define DAQ_FLAG_CMPL_DAQ_CH              ((uint8_t)0x04) /* Complementary DAQ channel */
+#define DAQ_FLAG_TIMESTAMP                ((uint8_t)0x10) /* Timestamps */
+#define DAQ_FLAG_NO_PID                   ((uint8_t)0x20) /* No PID */
+#define DAQ_FLAG_RUNNING                  ((uint8_t)0x40) /* Is started */
+#define DAQ_FLAG_RESUME                   ((uint8_t)0x80) /* Resume Mode */
+#define DAQ_FLAG_RESERVED                 ((uint8_t)0x08)
+#define DAQ_FLAG_OVERRUN                  ((uint8_t)0x08) /* Overun (Internal Use) */
+
+
+/*-------------------------------------------------------------------------*/
+/* GET_DAQ_PROCESSOR_INFO */
+
+/* DAQ_PROPERTIES */
+#define DAQ_PROPERTY_CONFIG_TYPE          0x01
+#define DAQ_PROPERTY_PRESCALER            0x02
+#define DAQ_PROPERTY_RESUME               0x04
+#define DAQ_PROPERTY_BIT_STIM             0x08
+#define DAQ_PROPERTY_TIMESTAMP            0x10
+#define DAQ_PROPERTY_NO_PID               0x20
+#define DAQ_PROPERTY_OVERLOAD_INDICATION  0xC0
+
+/* DAQ Overload Indication Type */
+#define DAQ_OVERLOAD_INDICATION_NONE      (0<<6)
+#define DAQ_OVERLOAD_INDICATION_PID       (1<<6)
+#define DAQ_OVERLOAD_INDICATION_EVENT     (2<<6)
+
+/* DAQ_KEY_BYTE */
+#define DAQ_OPT_TYPE                      0x0F
+#define DAQ_EXT_TYPE                      0x30
+#define DAQ_HDR_TYPE                      0xC0
+
+/* DAQ Optimisation Type */
+#define DAQ_OPT_DEFAULT                   (0<<0)
+#define DAQ_OPT_ODT_16                    (1<<0)
+#define DAQ_OPT_ODT_32                    (2<<0)
+#define DAQ_OPT_ODT_64                    (3<<0)
+#define DAQ_OPT_ALIGNMENT                 (4<<0)
+#define DAQ_OPT_MAX_ENTRY_SIZE            (5<<0)
+
+/* DAQ Address Extension Scope */
+#define DAQ_EXT_FREE                      (0<<4)
+#define DAQ_EXT_ODT                       (1<<4)
+#define DAQ_EXT_DAQ                       (3<<4)
+
+/* DAQ Identification Field Type */
+#define DAQ_HDR_PID                       (0<<6)
+#define DAQ_HDR_ODT_DAQB                  (1<<6)
+#define DAQ_HDR_ODT_DAQW                  (2<<6)
+#define DAQ_HDR_ODT_FIL_DAQW              (3<<6)
+
+
+/*-------------------------------------------------------------------------*/
+/* GET_DAQ_RESOLUTION_INFO */
+
+/* TIMESTAMP_MODE Bitmasks */
+#define DAQ_TIMESTAMP_TYPE  0x07
+#define DAQ_TIMESTAMP_FIXED 0x08
+#define DAQ_TIMESTAMP_UNIT  0xF0
+
+/* DAQ Timestamp Type */
+#define DAQ_TIMESTAMP_OFF         (0<<0)
+#define DAQ_TIMESTAMP_BYTE        (1<<0)
+#define DAQ_TIMESTAMP_WORD        (2<<0)
+#define DAQ_TIMESTAMP_DWORD       (4<<0)
+
+/* DAQ Timestamp Unit */
+#define DAQ_TIMESTAMP_UNIT_1NS    (0<<4)
+#define DAQ_TIMESTAMP_UNIT_10NS   (1<<4)
+#define DAQ_TIMESTAMP_UNIT_100NS  (2<<4)
+#define DAQ_TIMESTAMP_UNIT_1US    (3<<4)
+#define DAQ_TIMESTAMP_UNIT_10US   (4<<4)
+#define DAQ_TIMESTAMP_UNIT_100US  (5<<4)
+#define DAQ_TIMESTAMP_UNIT_1MS    (6<<4)
+#define DAQ_TIMESTAMP_UNIT_10MS   (7<<4)
+#define DAQ_TIMESTAMP_UNIT_100MS  (8<<4)
+#define DAQ_TIMESTAMP_UNIT_1S     (9<<4)
+
+
+/*-------------------------------------------------------------------------*/
+/* DAQ_LIST_PROPERTIES (GET_DAQ_LIST_INFO) */
+
+#define DAQ_LIST_PREDEFINED           0x01
+#define DAQ_LIST_FIXED_EVENT          0x02
+#define DAQ_LIST_DIR_DAQ              0x04
+#define DAQ_LIST_DIR_STIM             0x08
+#define DAQ_LIST_PACKED               0x10
+
+
+/*-------------------------------------------------------------------------*/
+/* EVENT_PROPERTY (GET_DAQ_EVENT_INFO) */
+
+#define DAQ_EVENT_DIRECTION_DAQ      0x04
+#define DAQ_EVENT_DIRECTION_STIM     0x08
+#define DAQ_EVENT_DIRECTION_DAQ_STIM 0x0C
+
+
+/*-------------------------------------------------------------------------*/
+/* Comm mode programming parameter (PROGRAM_START) */
+
+#define PI_PGM_BLOCK_DOWNLOAD      0x01
+#define PI_PGM_BLOCK_UPLOAD        0x40
+
+
+/*-------------------------------------------------------------------------*/
+/* PGM_PROPERTIES (GET_PGM_PROCESSOR_INFO) */
+
+#define PGM_ACCESS_TYPE                   0x03
+#define PGM_COMPRESSION_TYPE              0x0C
+#define PGM_ENCRYPTION_TYPE               0x30
+#define PGM_NON_SEQ_TYPE                  0xC0
+
+/* PGM Access Mode */
+#define PGM_ACCESS_ABSOLUTE               (1<<0)
+#define PGM_ACCESS_FUNCTIONAL             (2<<0)
+#define PGM_ACCESS_FREE                   (3<<0)
+
+/* PGM Compression type */
+#define PGM_COMPRESSION_NONE              (0<<2)
+#define PGM_COMPRESSION_SUPPORTED         (1<<2)
+#define PGM_COMPRESSION_REQUIRED          (3<<2)
+
+/* PGM Encryption type */
+#define PGM_ENCRYPTION_NONE               (0<<4)
+#define PGM_ENCRYPTION_SUPPORTED          (1<<4)
+#define PGM_ENCRYPTION_REQUIRED           (3<<4)
+
+/* PGM non sequential programming type */
+#define PGM_NON_SEQ_NONE                  (0<<6)
+#define PGM_NON_SEQ_SUPPORTED             (1<<6)
+#define PGM_NON_SEQ_REQUIRED              (3<<6)
+
+
+/***************************************************************************/
+/* XCP Protocol Commands and Responces, Type Definition */
+/***************************************************************************/
+
+/* Protocol command structure definition */
+#define CRO_CMD                                         CRO_BYTE(0)
+#define CRM_CMD                                         CRM_BYTE(0)
+#define CRM_ERR                                         CRM_BYTE(1)
+#define CRM_EVENTCODE                                   CRM_BYTE(1)
+
+
+
+/* CONNECT */
+#define CRO_CONNECT_LEN                                 2
+#define CRO_CONNECT_MODE                                CRO_BYTE(1)
+#define CRM_CONNECT_LEN                                 8
+#define CRM_CONNECT_RESOURCE                            CRM_BYTE(1)
+#define CRM_CONNECT_COMM_BASIC                          CRM_BYTE(2)
+#define CRM_CONNECT_MAX_CTO_SIZE                        CRM_BYTE(3)
+#define CRM_CONNECT_MAX_DTO_SIZE                        CRM_WORD(2)
+#define CRM_CONNECT_PROTOCOL_VERSION                    CRM_BYTE(6)
+#define CRM_CONNECT_TRANSPORT_VERSION                   CRM_BYTE(7)
+
+
+/* DISCONNECT */
+#define CRO_DISCONNECT_LEN                              1
+#define CRM_DISCONNECT_LEN                              1
+
+
+/* GET_STATUS */
+#define CRO_GET_STATUS_LEN                              1
+#define CRM_GET_STATUS_LEN                              6
+#define CRM_GET_STATUS_STATUS                           CRM_BYTE(1)
+#define CRM_GET_STATUS_PROTECTION                       CRM_BYTE(2)
+#define CRM_GET_STATUS_CONFIG_ID                        CRM_WORD(2)
+
+/* SYNCH */
+#define CRO_SYNCH_LEN                                   1
+#define CRM_SYNCH_LEN                                   2
+#define CRM_SYNCH_RESULT                                CRM_BYTE(1)
+
+
+/* GET_COMM_MODE_INFO */
+#define CRO_GET_COMM_MODE_INFO_LEN                      1
+#define CRM_GET_COMM_MODE_INFO_LEN                      8
+#define CRM_GET_COMM_MODE_INFO_COMM_OPTIONAL            CRM_BYTE(2)
+#define CRM_GET_COMM_MODE_INFO_MAX_BS                   CRM_BYTE(4)
+#define CRM_GET_COMM_MODE_INFO_MIN_ST                   CRM_BYTE(5)
+#define CRM_GET_COMM_MODE_INFO_QUEUE_SIZE               CRM_BYTE(6)
+#define CRM_GET_COMM_MODE_INFO_DRIVER_VERSION           CRM_BYTE(7)
+
+
+/* GET_ID */
+#define CRO_GET_ID_LEN                                  2
+#define CRO_GET_ID_TYPE                                 CRO_BYTE(1)
+#define CRM_GET_ID_LEN                                  8
+#define CRM_GET_ID_MODE                                 CRM_BYTE(1)
+#define CRM_GET_ID_LENGTH                               CRM_DWORD(1)
+#define CRM_GET_ID_DATA                                 (&CRM_BYTE(8))
+#define CRM_GET_ID_DATA_MAX_LEN                         (sizeof(CRM)-8)
+
+/* SET_REQUEST */
+#define CRO_SET_REQUEST_LEN                             4
+#define CRO_SET_REQUEST_MODE                            CRO_BYTE(1)
+#define CRO_SET_REQUEST_CONFIG_ID                       CRO_WORD(1)
+#define CRM_SET_REQUEST_LEN                             1
+
+
+/* GET_SEED */
+#define CRO_GET_SEED_LEN                                3
+#define CRO_GET_SEED_MODE                               CRO_BYTE(1)
+#define CRO_GET_SEED_RESOURCE                           CRO_BYTE(2)
+#define CRM_GET_SEED_LEN                                (CRM_GET_SEED_LENGTH+2u)
+#define CRM_GET_SEED_LENGTH                             CRM_BYTE(1)
+#define CRM_GET_SEED_DATA                               (&CRM_BYTE(2))
+
+
+/* UNLOCK */
+#define CRO_UNLOCK_LEN                                  8
+#define CRO_UNLOCK_LENGTH                               CRO_BYTE(1)
+#define CRO_UNLOCK_KEY                                  (&CRO_BYTE(2))
+#define CRM_UNLOCK_LEN                                  2
+#define CRM_UNLOCK_PROTECTION                           CRM_BYTE(1)
+
+
+/* SET_MTA */
+#define CRO_SET_MTA_LEN                                 8
+#define CRO_SET_MTA_EXT                                 CRO_BYTE(3)
+#define CRO_SET_MTA_ADDR                                CRO_DWORD(1)
+#define CRM_SET_MTA_LEN                                 1
+
+
+/* UPLOAD */
+#define CRM_UPLOAD_MAX_SIZE                             ((uint8_t)(XCPTL_MAX_CTO_SIZE-1))
+#define CRO_UPLOAD_LEN                                  2
+#define CRO_UPLOAD_SIZE                                 CRO_BYTE(1)
+#define CRM_UPLOAD_LEN                                  1 /* +CRO_UPLOAD_SIZE */
+#define CRM_UPLOAD_DATA                                 (&CRM_BYTE(1))
+
+
+/* SHORT_UPLOAD */
+#define CRO_SHORT_UPLOAD_LEN                            8
+#define CRO_SHORT_UPLOAD_SIZE                           CRO_BYTE(1)
+#define CRO_SHORT_UPLOAD_EXT                            CRO_BYTE(3)
+#define CRO_SHORT_UPLOAD_ADDR                           CRO_DWORD(1)
+#define CRM_SHORT_UPLOAD_MAX_SIZE                       ((uint8_t)(XCPTL_MAX_CTO_SIZE-1))
+#define CRM_SHORT_UPLOAD_LEN                            1u /* +CRO_SHORT_UPLOAD_SIZE */
+#define CRM_SHORT_UPLOAD_DATA                           (&CRM_BYTE(1))
+
+
+/* BUILD_CHECKSUM */
+#define CRO_BUILD_CHECKSUM_LEN                          8
+#define CRO_BUILD_CHECKSUM_SIZE                         CRO_DWORD(1)
+#define CRM_BUILD_CHECKSUM_LEN                          8
+#define CRM_BUILD_CHECKSUM_TYPE                         CRM_BYTE(1)
+#define CRM_BUILD_CHECKSUM_RESULT                       CRM_DWORD(1)
+
+
+/* DOWNLOAD */
+#define CRO_DOWNLOAD_MAX_SIZE                           ((uint8_t)(XCPTL_MAX_CTO_SIZE-2))
+#define CRO_DOWNLOAD_LEN                                2 /* + CRO_DOWNLOAD_SIZE */
+#define CRO_DOWNLOAD_SIZE                               CRO_BYTE(1)
+#define CRO_DOWNLOAD_DATA                               (&CRO_BYTE(2))
+#define CRM_DOWNLOAD_LEN                                1
+
+
+/* DOWNLOAD_NEXT */
+#define CRO_DOWNLOAD_NEXT_MAX_SIZE                      ((uint8_t)(XCPTL_MAX_CTO_SIZE-2))
+#define CRO_DOWNLOAD_NEXT_LEN                           2 /* + size */
+#define CRO_DOWNLOAD_NEXT_SIZE                          CRO_BYTE(1)
+#define CRO_DOWNLOAD_NEXT_DATA                          (&CRO_BYTE(2))
+#define CRM_DOWNLOAD_NEXT_LEN                           1
+
+
+/* DOWNLOAD_MAX */
+#define CRO_DOWNLOAD_MAX_MAX_SIZE                       ((uint8_t)(XCPTL_MAX_CTO_SIZE-1))
+#define CRO_DOWNLOAD_MAX_DATA                           (&CRO_BYTE(1))
+#define CRM_DOWNLOAD_MAX_LEN                            1
+
+
+/* SHORT_DOWNLOAD */
+#define CRO_SHORT_DOWNLOAD_MAX_SIZE                     ((uint8_t)(XCPTL_MAX_CTO_SIZE-8))
+#define CRO_SHORT_DOWNLOAD_LEN                          8
+#define CRO_SHORT_DOWNLOAD_SIZE                         CRO_BYTE(1)
+#define CRO_SHORT_DOWNLOAD_EXT                          CRO_BYTE(3)
+#define CRO_SHORT_DOWNLOAD_ADDR                         CRO_DWORD(1)
+#define CRO_SHORT_DOWNLOAD_DATA                         (&CRO_BYTE(8))
+#define CRM_SHORT_DOWNLOAD_LEN                          1 /* +CRO_SHORT_UPLOAD_SIZE */
+
+
+/* MODIFY_BITS */
+#define CRO_MODIFY_BITS_LEN                             6
+#define CRO_MODIFY_BITS_SHIFT                           CRO_BYTE(1)
+#define CRO_MODIFY_BITS_AND                             CRO_WORD(1)
+#define CRO_MODIFY_BITS_XOR                             CRO_WORD(2)
+#define CRM_MODIFY_BITS_LEN                             1
+
+
+/* SET_CAL_PAGE */
+#define CRO_SET_CAL_PAGE_LEN                            4
+#define CRO_SET_CAL_PAGE_MODE                           CRO_BYTE(1)
+#define CRO_SET_CAL_PAGE_SEGMENT                        CRO_BYTE(2)
+#define CRO_SET_CAL_PAGE_PAGE                           CRO_BYTE(3)
+#define CRM_SET_CAL_PAGE_LEN                            1
+
+
+/* GET_CAL_PAGE */
+#define CRO_GET_CAL_PAGE_LEN                            3
+#define CRO_GET_CAL_PAGE_MODE                           CRO_BYTE(1)
+#define CRO_GET_CAL_PAGE_SEGMENT                        CRO_BYTE(2)
+#define CRM_GET_CAL_PAGE_LEN                            4
+#define CRM_GET_CAL_PAGE_PAGE                           CRM_BYTE(3)
+
+
+/* GET_PAG_PROCESSOR_INFO */
+#define CRO_GET_PAG_PROCESSOR_INFO_LEN                  1
+#define CRM_GET_PAG_PROCESSOR_INFO_LEN                  3
+#define CRM_GET_PAG_PROCESSOR_INFO_MAX_SEGMENT          CRM_BYTE(1)
+#define CRM_GET_PAG_PROCESSOR_INFO_PROPERTIES           CRM_BYTE(2)
+
+
+/* GET_SEGMENT_INFO */
+#define CRO_GET_SEGMENT_INFO_LEN                        5
+#define CRO_GET_SEGMENT_INFO_MODE                       CRO_BYTE(1)
+#define CRO_GET_SEGMENT_INFO_NUMBER                     CRO_BYTE(2)
+#define CRO_GET_SEGMENT_INFO_MAPPING_INDEX              CRO_BYTE(3)
+#define CRO_GET_SEGMENT_INFO_MAPPING                    CRO_BYTE(4)
+#define CRM_GET_SEGMENT_INFO_LEN                        8
+#define CRM_GET_SEGMENT_INFO_MAX_PAGES                  CRM_BYTE(1)
+#define CRM_GET_SEGMENT_INFO_ADDRESS_EXTENSION          CRM_BYTE(2)
+#define CRM_GET_SEGMENT_INFO_MAX_MAPPING                CRM_BYTE(3)
+#define CRM_GET_SEGMENT_INFO_COMPRESSION                CRM_BYTE(4)
+#define CRM_GET_SEGMENT_INFO_ENCRYPTION                 CRM_BYTE(5)
+#define CRM_GET_SEGMENT_INFO_MAPPING_INFO               CRM_DWORD(1)
+
+
+/* GET_PAGE_INFO */
+#define CRO_GET_PAGE_INFO_LEN                           4
+#define CRO_GET_PAGE_INFO_SEGMENT_NUMBER                CRO_BYTE(2)
+#define CRO_GET_PAGE_INFO_PAGE_NUMBER                   CRO_BYTE(3)
+#define CRM_GET_PAGE_INFO_LEN                           3
+#define CRM_GET_PAGE_INFO_PROPERTIES                    CRM_BYTE(1)
+#define CRM_GET_PAGE_INFO_INIT_SEGMENT                  CRM_BYTE(2)
+
+
+/* SET_SEGMENT_MODE */
+#define CRO_SET_SEGMENT_MODE_LEN                        3
+#define CRO_SET_SEGMENT_MODE_MODE                       CRO_BYTE(1)
+#define CRO_SET_SEGMENT_MODE_SEGMENT                    CRO_BYTE(2)
+#define CRM_SET_SEGMENT_MODE_LEN                        1
+
+
+/* GET_SEGMENT_MODE */
+#define CRO_GET_SEGMENT_MODE_LEN                        3
+#define CRO_GET_SEGMENT_MODE_SEGMENT                    CRO_BYTE(2)
+#define CRM_GET_SEGMENT_MODE_LEN                        3
+#define CRM_GET_SEGMENT_MODE_MODE                       CRM_BYTE(2)
+
+
+/* COPY_CAL_PAGE */
+#define CRO_COPY_CAL_PAGE_LEN                           5
+#define CRO_COPY_CAL_PAGE_SRC_SEGMENT                   CRO_BYTE(1)
+#define CRO_COPY_CAL_PAGE_SRC_PAGE                      CRO_BYTE(2)
+#define CRO_COPY_CAL_PAGE_DEST_SEGMENT                  CRO_BYTE(3)
+#define CRO_COPY_CAL_PAGE_DEST_PAGE                     CRO_BYTE(4)
+#define CRM_COPY_CAL_PAGE_LEN                           1
+
+
+/* CLEAR_DAQ_LIST */
+#define CRO_CLEAR_DAQ_LIST_LEN                          4
+#define CRO_CLEAR_DAQ_LIST_DAQ                          CRO_WORD(1)
+#define CRM_CLEAR_DAQ_LIST_LEN                          1
+
+
+/* SET_DAQ_PTR */
+#define CRO_SET_DAQ_PTR_LEN                             6
+#define CRO_SET_DAQ_PTR_DAQ                             CRO_WORD(1)
+#define CRO_SET_DAQ_PTR_ODT                             CRO_BYTE(4)
+#define CRO_SET_DAQ_PTR_IDX                             CRO_BYTE(5)
+#define CRM_SET_DAQ_PTR_LEN                             1
+
+
+/* WRITE_DAQ */
+#define CRO_WRITE_DAQ_LEN                               8
+#define CRO_WRITE_DAQ_BITOFFSET                         CRO_BYTE(1)
+#define CRO_WRITE_DAQ_SIZE                              CRO_BYTE(2)
+#define CRO_WRITE_DAQ_EXT                               CRO_BYTE(3)
+#define CRO_WRITE_DAQ_ADDR                              CRO_DWORD(1)
+#define CRM_WRITE_DAQ_LEN                               1
+
+
+/* WRITE_DAQ_MULTIPLE */
+#define CRO_WRITE_DAQ_MULTIPLE_LEN                      8
+#define CRO_WRITE_DAQ_MULTIPLE_NODAQ                    CRO_BYTE(1)
+#define CRO_WRITE_DAQ_MULTIPLE_BITOFFSET(i)             CRO_BYTE(2 + (8*(i)))
+#define CRO_WRITE_DAQ_MULTIPLE_SIZE(i)                  CRO_BYTE(3 + (8*(i)))
+#define CRO_WRITE_DAQ_MULTIPLE_ADDR(i)                  CRO_DWORD(1 + (2*(i)))
+#define CRO_WRITE_DAQ_MULTIPLE_EXT(i)                   CRO_BYTE(8 + (8*(i)))
+#define CRM_WRITE_DAQ_MULTIPLE_LEN                      1
+
+
+/* SET_DAQ_LIST_MODE */
+#define CRO_SET_DAQ_LIST_MODE_LEN                       8
+#define CRO_SET_DAQ_LIST_MODE_MODE                      CRO_BYTE(1)
+#define CRO_SET_DAQ_LIST_MODE_DAQ                       CRO_WORD(1)
+#define CRO_SET_DAQ_LIST_MODE_EVENTCHANNEL              CRO_WORD(2)
+#define CRO_SET_DAQ_LIST_MODE_PRESCALER                 CRO_BYTE(6)
+#define CRO_SET_DAQ_LIST_MODE_PRIORITY                  CRO_BYTE(7)
+#define CRM_SET_DAQ_LIST_MODE_LEN                       6
+
+
+/* GET_DAQ_LIST_MODE */
+#define CRO_GET_DAQ_LIST_MODE_LEN                       4
+#define CRO_GET_DAQ_LIST_MODE_DAQ                       CRO_WORD(1)
+#define CRM_GET_DAQ_LIST_MODE_LEN                       8
+#define CRM_GET_DAQ_LIST_MODE_MODE                      CRM_BYTE(1)
+#define CRM_GET_DAQ_LIST_MODE_EVENTCHANNEL              CRM_WORD(2)
+#define CRM_GET_DAQ_LIST_MODE_PRESCALER                 CRM_BYTE(6)
+#define CRM_GET_DAQ_LIST_MODE_PRIORITY                  CRM_BYTE(7)
+
+
+/* START_STOP_DAQ_LIST */
+#define CRO_START_STOP_LEN                              4
+#define CRO_START_STOP_MODE                             CRO_BYTE(1)
+#define CRO_START_STOP_DAQ                              CRO_WORD(1)
+#define CRM_START_STOP_LEN                              2
+#define CRM_START_STOP_FIRST_PID                        CRM_BYTE(1)
+
+
+/* START_STOP_SYNCH */
+#define CRO_START_STOP_SYNC_LEN                         2
+#define CRO_START_STOP_SYNC_MODE                        CRO_BYTE(1)
+#define CRM_START_STOP_SYNC_LEN                         1
+
+
+/* GET_DAQ_CLOCK */
+#define CRO_GET_DAQ_CLOCK_LEN                           1
+#define CRM_GET_DAQ_CLOCK_LEN                           8
+
+#if XCP_PROTOCOL_LAYER_VERSION >= 0x0103
+#define CRM_GET_DAQ_CLOCK_RES1                          CRM_BYTE(1)   // 1
+#define CRM_GET_DAQ_CLOCK_TRIGGER_INFO                  CRM_BYTE(2)   // 2
+#define CRM_GET_DAQ_CLOCK_PAYLOAD_FMT                   CRM_BYTE(3)   // 3
+
+#define CRM_GET_DAQ_CLOCK_TIME                          CRM_DWORD(1)  // 4
+#define CRM_GET_DAQ_CLOCK_SYNC_STATE                    CRM_BYTE(8)   // 8
+
+#define CRM_GET_DAQ_CLOCK_TIME64_LOW                    CRM_DWORD(1)  // 4
+#define CRM_GET_DAQ_CLOCK_TIME64_HIGH                   CRM_DWORD(2)  // 8
+#define CRM_GET_DAQ_CLOCK_SYNC_STATE64                  CRM_BYTE(12)  // 12
+#else
+#define CRM_GET_DAQ_CLOCK_TIME                          CRM_DWORD(1)  // 4
+#endif
+
+#define DAQ_CLOCK_PAYLOAD_FMT_SLV_32   (1<<0)
+#define DAQ_CLOCK_PAYLOAD_FMT_SLV_64   (2<<0) 
+#define DAQ_CLOCK_PAYLOAD_FMT_ID       (1<<6)
+
+/* GET_DAQ_CLOCK_MULTICAST */
+#if XCP_PROTOCOL_LAYER_VERSION >= 0x0103
+#define CRO_GET_DAQ_CLOC_MCAST_LEN                      4
+#define CRM_GET_DAQ_CLOCK_MCAST_LEN                     8
+
+#define CRO_GET_DAQ_CLOCK_MCAST_CLUSTER_IDENTIFIER      CRO_WORD(1)
+#define CRO_GET_DAQ_CLOCK_MCAST_COUNTER                 CRO_BYTE(4)
+
+#define CRM_GET_DAQ_CLOCK_MCAST_TRIGGER_INFO            CRM_BYTE(2)   // 2
+#define CRM_GET_DAQ_CLOCK_MCAST_PAYLOAD_FMT             CRM_BYTE(3)   // 3
+
+#define CRM_GET_DAQ_CLOCK_MCAST_TIME                    CRM_DWORD(1)  // 4
+#define CRM_GET_DAQ_CLOCK_MCAST_CLUSTER_IDENTIFIER      CRM_WORD(4)   // 8
+#define CRM_GET_DAQ_CLOCK_MCAST_COUNTER                 CRM_BYTE(10)  // 10
+#define CRM_GET_DAQ_CLOCK_MCAST_SYNC_STATE              CRM_BYTE(11)  // 11
+
+#define CRM_GET_DAQ_CLOCK_MCAST_TIME64_LOW              CRM_DWORD(1)  // 4
+#define CRM_GET_DAQ_CLOCK_MCAST_TIME64_HIGH             CRM_DWORD(2)  // 8
+#define CRM_GET_DAQ_CLOCK_MCAST_CLUSTER_IDENTIFIER64    CRM_WORD(6)   // 12
+#define CRM_GET_DAQ_CLOCK_MCAST_COUNTER64               CRM_BYTE(14)  // 14
+#define CRM_GET_DAQ_CLOCK_MCAST_SYNC_STATE64            CRM_BYTE(15)  // 15
+#endif
+
+/* READ_DAQ */
+#define CRO_READ_DAQ_LEN                                1
+#define CRM_READ_DAQ_LEN                                8
+#define CRM_READ_DAQ_BITOFFSET                          CRM_BYTE(1)
+#define CRM_READ_DAQ_SIZE                               CRM_BYTE(2)
+#define CRM_READ_DAQ_EXT                                CRM_BYTE(3)
+#define CRM_READ_DAQ_ADDR                               CRM_DWORD(1)
+
+
+/* GET_DAQ_PROCESSOR_INFO */
+#define CRO_GET_DAQ_PROCESSOR_INFO_LEN                  1
+#define CRM_GET_DAQ_PROCESSOR_INFO_LEN                  8
+#define CRM_GET_DAQ_PROCESSOR_INFO_PROPERTIES           CRM_BYTE(1)
+#define CRM_GET_DAQ_PROCESSOR_INFO_MAX_DAQ              CRM_WORD(1)
+#define CRM_GET_DAQ_PROCESSOR_INFO_MAX_EVENT            CRM_WORD(2)
+#define CRM_GET_DAQ_PROCESSOR_INFO_MIN_DAQ              CRM_BYTE(6)
+#define CRM_GET_DAQ_PROCESSOR_INFO_DAQ_KEY_BYTE         CRM_BYTE(7)
+
+
+/* GET_DAQ_RESOLUTION_INFO */
+#define CRO_GET_DAQ_RESOLUTION_INFO_LEN                 1
+#define CRM_GET_DAQ_RESOLUTION_INFO_LEN                 8
+#define CRM_GET_DAQ_RESOLUTION_INFO_GRANULARITY_DAQ     CRM_BYTE(1)
+#define CRM_GET_DAQ_RESOLUTION_INFO_MAX_SIZE_DAQ        CRM_BYTE(2)
+#define CRM_GET_DAQ_RESOLUTION_INFO_GRANULARITY_STIM    CRM_BYTE(3)
+#define CRM_GET_DAQ_RESOLUTION_INFO_MAX_SIZE_STIM       CRM_BYTE(4)
+#define CRM_GET_DAQ_RESOLUTION_INFO_TIMESTAMP_MODE      CRM_BYTE(5)
+#define CRM_GET_DAQ_RESOLUTION_INFO_TIMESTAMP_TICKS     CRM_WORD(3)
+#define CRM_GET_DAQ_RESOLUTION_INFO_TIMESTAMP_TICKS_WRITE(ticks) CRM_WORD_WRITE(3, ticks)
+
+
+/* GET_DAQ_LIST_INFO */
+#define CRO_GET_DAQ_LIST_INFO_LEN                       4
+#define CRO_GET_DAQ_LIST_INFO_DAQ                       CRO_WORD(1)
+#define CRM_GET_DAQ_LIST_INFO_LEN                       6
+#define CRM_GET_DAQ_LIST_INFO_PROPERTIES                CRM_BYTE(1)
+#define CRM_GET_DAQ_LIST_INFO_MAX_ODT                   CRM_BYTE(2)
+#define CRM_GET_DAQ_LIST_INFO_MAX_ODT_ENTRY             CRM_BYTE(3)
+#define CRM_GET_DAQ_LIST_INFO_FIXED_EVENT               CRM_WORD(2)
+
+
+/* GET_DAQ_EVENT_INFO */
+#define CRO_GET_DAQ_EVENT_INFO_LEN                      4
+#define CRO_GET_DAQ_EVENT_INFO_EVENT                    CRO_WORD(1)
+#define CRM_GET_DAQ_EVENT_INFO_LEN                      7
+#define CRM_GET_DAQ_EVENT_INFO_PROPERTIES               CRM_BYTE(1)
+#define CRM_GET_DAQ_EVENT_INFO_MAX_DAQ_LIST             CRM_BYTE(2)
+#define CRM_GET_DAQ_EVENT_INFO_NAME_LENGTH              CRM_BYTE(3)
+#define CRM_GET_DAQ_EVENT_INFO_TIME_CYCLE               CRM_BYTE(4)
+#define CRM_GET_DAQ_EVENT_INFO_TIME_UNIT                CRM_BYTE(5)
+#define CRM_GET_DAQ_EVENT_INFO_PRIORITY                 CRM_BYTE(6)
+
+
+#define DAQ_EVENT_PROPERTIES_DAQ      0x04
+#define DAQ_EVENT_PROPERTIES_STIM     0x08
+#define DAQ_EVENT_PROPERTIES_PACKED   0x10
+#define DAQ_EVENT_PROPERTIES_EVENT_CONSISTENCY  0x80
+
+
+/* FREE_DAQ */
+#define CRO_FREE_DAQ_LEN                                1
+#define CRM_FREE_DAQ_LEN                                1
+
+
+/* ALLOC_DAQ */
+#define CRO_ALLOC_DAQ_LEN                               4
+#define CRO_ALLOC_DAQ_COUNT                             CRO_WORD(1)
+#define CRM_ALLOC_DAQ_LEN                               1
+
+
+/* ALLOC_ODT */
+#define _CRO_ALLOC_ODT_LEN                              3
+#define _CRO_ALLOC_ODT_DAQ                              CRO_WORD(1)
+#define _CRO_ALLOC_ODT_COUNT                            CRO_BYTE(1)
+#define CRO_ALLOC_ODT_LEN                               5
+#define CRO_ALLOC_ODT_DAQ                               CRO_WORD(1)
+#define CRO_ALLOC_ODT_COUNT                             CRO_BYTE(4)
+#define CRM_ALLOC_ODT_LEN                               1
+
+
+/* ALLOC_ODT_ENTRY */
+#define CRO_ALLOC_ODT_ENTRY_LEN                         6
+#define CRO_ALLOC_ODT_ENTRY_DAQ                         CRO_WORD(1)
+#define CRO_ALLOC_ODT_ENTRY_ODT                         CRO_BYTE(4)
+#define CRO_ALLOC_ODT_ENTRY_COUNT                       CRO_BYTE(5)
+#define CRM_ALLOC_ODT_ENTRY_LEN                         1
+
+
+/* PROGRAM_START */
+#define CRO_PROGRAM_START_LEN                           1
+#define CRM_PROGRAM_START_LEN                           7
+#define CRM_PROGRAM_COMM_MODE_PGM                       CRM_BYTE(2)
+#define CRM_PROGRAM_MAX_CTO_PGM                         CRM_BYTE(3)
+#define CRM_PROGRAM_MAX_BS_PGM                          CRM_BYTE(4)
+#define CRM_PROGRAM_MIN_ST_PGM                          CRM_BYTE(5)
+#define CRM_PROGRAM_QUEUE_SIZE_PGM                      CRM_BYTE(6)
+
+
+/* PROGRAM_CLEAR */
+#define CRO_PROGRAM_CLEAR_LEN                           8
+#define CRO_PROGRAM_CLEAR_MODE                          CRO_BYTE(1)
+#define CRO_PROGRAM_CLEAR_SIZE                          CRO_DWORD(1)
+#define CRM_PROGRAM_CLEAR_LEN                           1
+
+
+/* PROGRAM */
+#define CRO_PROGRAM_MAX_SIZE                            ((uint8_t)(XCPTL_MAX_CTO_SIZE-2))
+#define CRO_PROGRAM_LEN                                 2 /* + CRO_PROGRAM_SIZE */
+#define CRO_PROGRAM_SIZE                                CRO_BYTE(1)
+#define CRO_PROGRAM_DATA                                (&CRO_BYTE(2))
+#define CRM_PROGRAM_LEN                                 1
+
+
+/* PROGRAM RESET */
+#define CRO_PROGRAM_RESET_LEN                           1
+#define CRM_PROGRAM_RESET_LEN                           1
+
+
+/* GET_PGM_PROCESSOR_INFO*/
+#define CRO_GET_PGM_PROCESSOR_INFO_LEN                  1
+#define CRM_GET_PGM_PROCESSOR_INFO_LEN                  3
+#define CRM_GET_PGM_PROCESSOR_INFO_PROPERTIES           CRM_BYTE(1)
+#define CRM_GET_PGM_PROCESSOR_INFO_MAX_SECTOR           CRM_BYTE(2)
+
+
+/* GET_SECTOR_INFO */
+#define CRO_PROGRAM_GET_SECTOR_INFO_LEN                 3
+#define CRO_PROGRAM_GET_SECTOR_INFO_MODE                CRO_BYTE(1)
+#define CRO_PROGRAM_GET_SECTOR_INFO_NUMBER              CRO_BYTE(2)
+#define CRM_PROGRAM_GET_SECTOR_INFO_LEN                 8
+#define CRM_PROGRAM_GET_SECTOR_CLEAR_SEQ_NUM            CRM_BYTE(1)
+#define CRM_PROGRAM_GET_SECTOR_PGM_SEQ_NUM              CRM_BYTE(2)
+#define CRM_PROGRAM_GET_SECTOR_PGM_METHOD               CRM_BYTE(3)
+#define CRM_PROGRAM_GET_SECTOR_SECTOR_INFO              CRM_DWORD(1)
+#define CRM_PROGRAM_GET_SECTOR_SECTOR_INFO_WRITE(info)  CRM_DWORD_WRITE(1, info)
+
+
+/* PROGRAM_PREPARE */
+#define CRO_PROGRAM_PREPARE_LEN                         4
+#define CRO_PROGRAM_PREPARE_SIZE                        CRO_WORD(1)
+#define CRM_PROGRAM_PREPARE_LEN                         1
+
+
+/* PROGRAM_FORMAT */
+#define CRO_PROGRAM_FORMAT_LEN                          5
+#define CRO_PROGRAM_FORMAT_COMPRESSION_METHOD           CRO_BYTE(1)
+#define CRO_PROGRAM_FORMAT_ENCRYPTION_METHOD            CRO_BYTE(2)
+#define CRO_PROGRAM_FORMAT_PROGRAMMING_METHOD           CRO_BYTE(3)
+#define CRO_PROGRAM_FORMAT_ACCESS_METHOD                CRO_BYTE(4)
+#define CRM_PROGRAM_FORMAT_LEN                          1
+
+
+/* PROGRAM_NEXT */
+#define CRO_PROGRAM_NEXT_MAX_SIZE                       ((uint8_t)(XCPTL_MAX_CTO_SIZE-2))
+#define CRO_PROGRAM_NEXT_LEN                            2 /* + size */
+#define CRO_PROGRAM_NEXT_SIZE                           CRO_BYTE(1)
+#define CRO_PROGRAM_NEXT_DATA                           (&CRO_BYTE(2))
+#define CRM_PROGRAM_NEXT_LEN                            3
+#define CRM_PROGRAM_NEXT_ERR_SEQUENCE                   CRM_BYTE(1)
+#define CRM_PROGRAM_NEXT_SIZE_EXPECTED_DATA             CRM_BYTE(2)
+
+
+/* PROGRAM_MAX */
+#define CRO_PROGRAM_MAX_MAX_SIZE                        ((uint8_t)(XCPTL_MAX_CTO_SIZE-1))
+#define CRO_PROGRAM_MAX_DATA                            (&CRO_BYTE(1))
+#define CRM_PROGRAM_MAX_LEN                             1
+
+
+/* PROGRAM_VERIFY */
+#define CRO_PROGRAM_VERIFY_LEN                          8
+#define CRO_PROGRAM_VERIFY_MODE                         CRO_BYTE(1)
+#define CRO_PROGRAM_VERIFY_TYPE                         CRO_WORD(1)
+#define CRO_PROGRAM_VERIFY_VALUE                        CRO_DWORD(1)
+#define CRM_PROGRAM_VERIFY_LEN                          1
+
+
+/* GET_SERVER_ID */
+#define CRO_GET_SERVER_ID_LEN                            6
+#define CRO_GET_SERVER_ID_SUB_CODE                       CRO_BYTE(1)
+#define CRO_GET_SERVER_ID_X                              CRO_BYTE(2)
+#define CRO_GET_SERVER_ID_C                              CRO_BYTE(3)
+#define CRO_GET_SERVER_ID_P                              CRO_BYTE(4)
+#define CRO_GET_SERVER_ID_MODE                           CRO_BYTE(5)
+#define CRM_GET_SERVER_ID_LEN                            8
+#define CRM_GET_SERVER_ID_X                              CRM_BYTE(1)
+#define CRM_GET_SERVER_ID_C                              CRM_BYTE(2)
+#define CRM_GET_SERVER_ID_P                              CRM_BYTE(3)
+#define CRM_GET_SERVER_ID_CAN_ID_CMD_STIM                CRM_DWORD(1)
+
+
+/* GET_DAQ_ID */
+#define CRO_GET_DAQ_ID_LEN                              3
+#define CRO_GET_DAQ_ID_SUB_CODE                         CRO_BYTE(1)
+#define CRO_GET_DAQ_ID_DAQ                              CRO_WORD(1)
+#define CRM_GET_DAQ_ID_LEN                              8
+#define CRM_GET_DAQ_ID_FIXED                            CRM_BYTE(1)
+#define CRM_GET_DAQ_ID_ID                               CRM_DWORD(1)
+
+
+/* SET_DAQ_ID */
+#define CRO_SET_DAQ_ID_LEN                              8
+#define CRO_SET_DAQ_ID_SUB_CODE                         CRO_BYTE(1)
+#define CRO_SET_DAQ_ID_DAQ                              CRO_WORD(1)
+#define CRO_SET_DAQ_ID_ID                               CRO_DWORD(1)
+#define CRM_SET_DAQ_ID_LEN                              1
+
+
+/* SET_SERVER_PORT */
+#define CRO_SET_SERVER_PORT_LEN                          4
+#define CRO_SET_SERVER_PORT_SUB_CODE                     CRO_BYTE(1)
+#define CRO_SET_SERVER_PORT_PORT                         CRO_WORD(1)
+#define CRM_SET_SERVER_PORT                              1
+
+
+/* Level 1 commands */
+#define CRO_LEVEL_1_COMMAND_LEN                             2
+#define CRO_LEVEL_1_COMMAND_CODE                            CRO_BYTE(1)
+
+
+/* GET_VERSION */
+#define CRO_GET_VERSION_LEN                                 2
+#define CRM_GET_VERSION_LEN                                 6
+#define CRM_GET_VERSION_RESERVED                            CRM_BYTE(1)
+#define CRM_GET_VERSION_PROTOCOL_VERSION_MAJOR              CRM_BYTE(2)
+#define CRM_GET_VERSION_PROTOCOL_VERSION_MINOR              CRM_BYTE(3)
+#define CRM_GET_VERSION_TRANSPORT_VERSION_MAJOR             CRM_BYTE(4)
+#define CRM_GET_VERSION_TRANSPORT_VERSION_MINOR             CRM_BYTE(5)
+
+
+/* GET_DAQ_LIST_PACKED_MODE */
+#define CRO_GET_DAQ_LIST_PACKED_MODE_DAQ                    CRM_WORD(1)
+#define CRM_GET_DAQ_LIST_PACKED_MODE_LEN                    8
+#define CRM_GET_DAQ_LIST_PACKED_MODE_MODE                   CRM_BYTE(2)
+
+
+/* SET_DAQ_LIST_PACKED_MODE */
+#define CRO_SET_DAQ_LIST_PACKED_MODE_DAQ                    CRO_WORD(1)
+#define CRO_SET_DAQ_LIST_PACKED_MODE_MODE                   CRO_BYTE(4)
+#define CRO_SET_DAQ_LIST_PACKED_MODE_TIMEMODE               CRO_BYTE(5)
+#define CRO_SET_DAQ_LIST_PACKED_MODE_SAMPLECOUNT            CRO_WORD(3)
+
+
+/* TIME SYNCHRONIZATION PROPERTIES*/
+#define CRO_TIME_SYNC_PROPERTIES_LEN                        6
+#define CRO_TIME_SYNC_PROPERTIES_SET_PROPERTIES             CRO_BYTE(1)
+#define CRO_TIME_SYNC_PROPERTIES_GET_PROPERTIES_REQUEST     CRO_BYTE(2)
+#define CRO_TIME_SYNC_PROPERTIES_CLUSTER_ID                 CRO_WORD(2)
+
+/* CRO_TIME_SYNC_PROPERTIES_SET_PROPERTIES: */
+#define TIME_SYNC_SET_PROPERTIES_RESPONSE_FMT              (3 << 0)
+#define TIME_SYNC_SET_PROPERTIES_TIME_SYNC_BRIDGE          (3 << 2)
+#define TIME_SYNC_SET_PROPERTIES_CLUSTER_ID                (1 << 4)
+
+#define TIME_SYNC_RESPONSE_FMT_LEGACY                      0
+#define TIME_SYNC_RESPONSE_FMT_TRIGGER_SUBSET              1
+#define TIME_SYNC_RESPONSE_FMT_TRIGGER_ALL                 2
+
+/* CRO_TIME_SYNC_PROPERTIES_GET_PROPERTIES_REQUEST: */
+#define TIME_SYNC_GET_PROPERTIES_GET_CLK_INFO             (1 << 0)
+
+
+#define CRM_TIME_SYNC_PROPERTIES_LEN                        8
+#define CRM_TIME_SYNC_PROPERTIES_SERVER_CONFIG              CRM_BYTE(1)
+#define CRM_TIME_SYNC_PROPERTIES_OBSERVABLE_CLOCKS          CRM_BYTE(2)
+#define CRM_TIME_SYNC_PROPERTIES_SYNC_STATE                 CRM_BYTE(3)
+#define CRM_TIME_SYNC_PROPERTIES_CLOCK_INFO                 CRM_BYTE(4)
+#define CRM_TIME_SYNC_PROPERTIES_RESERVED                   CRM_BYTE(5)
+#define CRM_TIME_SYNC_PROPERTIES_CLUSTER_ID                 CRM_WORD(3)
+
+/* CRM_TIME_SYNC_PROPERTIES_SERVER_CONFIG: */
+#define SERVER_CONFIG_RESPONSE_FMT_LEGACY                    (0)
+#define SERVER_CONFIG_RESPONSE_FMT_ADVANCED                  (2)
+#define SERVER_CONFIG_DAQ_TS_ECU                             (1 << 2)
+#define SERVER_CONFIG_DAQ_TS_SERVER                          (0 << 2)
+#define SERVER_CONFIG_TIME_SYNC_BRIDGE_NONE                  (0 << 3)
+
+/* CRM_TIME_SYNC_PROPERTIES_OBSERVABLE_CLOCKS: */
+#define LOCAL_CLOCK_FREE_RUNNING    (0<<0)
+#define LOCAL_CLOCK_SYNCED          (1<<0)
+#define LOCAL_CLOCK_NONE            (2<<0)
+#define GRANDM_CLOCK_NONE           (0<<2)
+#define GRANDM_CLOCK_READABLE       (1<<2)
+#define GRANDM_CLOCK_EVENT          (2<<2)
+#define ECU_CLOCK_NONE              (0<<4)
+#define ECU_CLOCK_READABLE          (1<<4)
+#define ECU_CLOCK_EVENT             (2<<4)
+#define ECU_CLOCK_NOTREADABLE       (3<<4)
+
+/* CRM_TIME_SYNC_PROPERTIES_SYNC_STATE: */
+#define LOCAL_CLOCK_STATE_SYNCH_IN_PROGRESS       (0 << 0)
+#define LOCAL_CLOCK_STATE_SYNCH                   (1 << 0)
+#define LOCAL_CLOCK_STATE_SYNT_IN_PROGRESS        (2 << 0)
+#define LOCAL_CLOCK_STATE_SYNT                    (3 << 0)
+#define LOCAL_CLOCK_STATE_FREE_RUNNING            (7 << 0)
+#define GRANDM_CLOCK_STATE_SYNC_IN_PROGRESS       (0 << 3)
+#define GRANDM_CLOCK_STATE_SYNC                   (1 << 3)
+
+
+/* CRM_TIME_SYNC_PROPERTIES_CLOCK_INFO: */
+#define CLOCK_INFO_SERVER           (1<<0)
+#define CLOCK_INFO_GRANDM           (1<<1)
+#define CLOCK_INFO_RELATION         (1<<2)
+#define CLOCK_INFO_ECU              (1<<3)
+#define CLOCK_INFO_ECU_GRANDM       (1<<4)
+
+/* TRIGGER_INITIATOR:
+    0 = HW trigger, i.e.Vector Syncline
+    1 = Event derived from XCP - independent time synchronization event - e.g.globally synchronized pulse per second signal
+    2 = GET_DAQ_CLOCK_MULTICAST
+    3 = GET_DAQ_CLOCK_MULTICAST via Time Sync Bridge
+    4 = State change in syntonization / synchronization to grandmaster clock(either established or lost, additional information is provided by the SYNC_STATE field - see Table 236)
+    5 = Leap second occurred on grandmaster clock
+    6 = release of ECU reset
+*/
+#define TRIG_INITIATOR_SYNC_LINE                            0UL
+#define TRIG_INITIATOR_XCP_INDEPENDENT                      1UL
+#define TRIG_INITIATOR_MULTICAST                            2UL
+#define TRIG_INITIATOR_MULTICAST_TS_BRIDGE                  3UL
+#define TRIG_INITIATOR_SYNC_STATE_CHANGE                    4UL
+#define TRIG_INITIATOR_LEAP_SECOND                          5UL
+#define TRIG_INITIATOR_ECU_RESET_RELEASE                    6UL
+#define TRIG_INITIATOR_RESERVED                             7UL
+
+
+#define TIME_OF_TS_SAMPLING_PROTOCOL_PROCESSOR              0UL
+#define TIME_OF_TS_SAMPLING_LOW_JITTER                      1UL
+#define TIME_OF_TS_SAMPLING_PHY_TRANSMISSION                2UL
+#define TIME_OF_TS_SAMPLING_PHY_RECEPTION                   3UL
+
+
+/****************************************************************************/
+/* XCP clock information                                                    */
+/****************************************************************************/
+
+#define XCP_STRATUM_LEVEL_UNKNOWN   255
+#define XCP_STRATUM_LEVEL_ARB       16   // unsychronized
+#define XCP_STRATUM_LEVEL_UTC       0    // Atomic reference clock
+
+#define XCP_EPOCH_TAI 0 // Atomic monotonic time since 1.1.1970 (TAI)
+#define XCP_EPOCH_UTC 1 // Universal Coordinated Time (with leap seconds) since 1.1.1970 (UTC)
+#define XCP_EPOCH_ARB 2 // Arbitrary (unknown)
+
+#pragma pack(push, 1)
+
+typedef struct {
+    uint8_t      UUID[8];
+    uint16_t     timestampTicks;
+    uint8_t      timestampUnit;
+    uint8_t      stratumLevel;
+    uint8_t      nativeTimestampSize;
+    uint8_t      fill[3]; // for alignment (8 byte) of structure
+    uint64_t     valueBeforeWrapAround;
+} T_CLOCK_INFO;
+
+
+#ifdef XCP_ENABLE_PTP
+
+typedef struct {
+    uint8_t     UUID[8];
+    uint16_t    timestampTicks;
+    uint8_t     timestampUnit;
+    uint8_t     stratumLevel;
+    uint8_t     nativeTimestampSize;
+    uint8_t     epochOfGrandmaster;
+    uint8_t     fill[2]; // for alignment (8 byte) of structure
+    uint64_t    valueBeforeWrapAround;
+} T_CLOCK_INFO_GRANDMASTER;
+
+typedef struct {
+    uint64_t  timestampOrigin;
+    uint64_t  timestampLocal;
+} T_CLOCK_INFO_RELATION;
+
+#endif
+
+#pragma pack(pop)
+
+/***************************************************************************/
+/* XCP Transport Layer Commands and Responces, Type Definition */
+/***************************************************************************/
+
+
+/* Transport Layer commands */
+#define CC_TL_GET_SERVER_ID                                 0xFF
+#define CC_TL_GET_SERVER_ID_EXTENDED                        0xFD
+#define CC_TL_SET_SERVER_IP                                 0xFC
+#define CC_TL_GET_DAQ_CLOCK_MULTICAST                       0xFA
+#define CRO_TL_SUBCOMMAND                                   CRO_BYTE(1)
+
+/* GET_SERVER_ID */
+#define CRO_TL_SLV_DETECT_PORT                              CRO_WORD(1)
+#define CRO_TL_SLV_DETECT_MCAST_IP_ADDR                     CRO_DWORD(1)
+
+#define TL_SLV_DETECT_STATUS_PROTOCOL_TCP                   0
+#define TL_SLV_DETECT_STATUS_PROTOCOL_UDP                   1
+#define TL_SLV_DETECT_STATUS_PROTOCOL_TCP_UDP               2
+#define TL_SLV_DETECT_STATUS_PROTOCOL_RESERVED              3
+#define TL_SLV_DETECT_STATUS_IP_VERSION_IPV4                (0)
+#define TL_SLV_DETECT_STATUS_IP_VERSION_RESERVED            (1<<2)
+#define TL_SLV_DETECT_STATUS_SLV_AVAILABILITY_BUSY          (1<<3)
+#define TL_SLV_DETECT_STATUS_SLV_ID_EXT_SUPPORTED           (1<<4)
+
+/* GET_SERVER_ID_EXTENDED */
+#define TL_SLV_DETECT_STATUS_SLV_ID_EXT_RADAR_DATA          (1<<0)
+#define TL_SLV_DETECT_STATUS_SLV_ID_EXT_XCP_ON_PCIE         (1<<1)
+
+

--- a/Use_in_ECU/xcpLite.h
+++ b/Use_in_ECU/xcpLite.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include "main.h"
+#include "xcp_cfg.h"    // Protocol layer configuration
+#include "xcptl_cfg.h"  // Transport layer configuration
+#include "xcp.h"        // XCP protocol defines
+#include "xcpTl.h"      // Transport layer interface
+
+#ifdef XCP_ENABLE_DAQ_EVENT_LIST
+
+typedef struct {
+    const char* name;
+    uint32_t size; // ext event size
+    uint8_t timeUnit; // timeCycle unit, 1ns=0, 10ns=1, 100ns=2, 1us=3, ..., 1ms=6, ...
+    uint8_t timeCycle; // cycletime in units, 0 = sporadic or unknown
+    uint16_t sampleCount; // packed event sample count
+    uint16_t daqList; // associated DAQ list
+    uint8_t priority; // priority 0 = queued, 1 = pushing, 2 = realtime
+#ifdef XCP_ENABLE_MULTITHREAD_EVENTS
+    MUTEX mutex;
+#endif
+#ifdef XCP_ENABLE_TEST_CHECKS
+    uint64_t time; // last event time stamp
+#endif
+} tXcpEvent;
+
+#endif
+
+
+/* Trigger a XCP data acquisition or stimulation event */
+extern void XcpEvent(uint16_t event);
+
+/* Send an XCP event message */
+extern void XcpSendEvent(uint8_t evc, const uint8_t* d, uint8_t l);
+
+// Event list
+#ifdef XCP_ENABLE_DAQ_EVENT_LIST
+
+// Add a measurement event to event list, return event number (0..MAX_EVENT-1)
+extern uint16_t XcpCreateEvent(const char* name, uint32_t cycleTimeNs /* ns */, uint8_t priority /* 0-normal, >=1 realtime*/, uint16_t sampleCount, uint32_t size);
+// Get event list
+extern tXcpEvent* XcpGetEventList(uint16_t* eventCount);
+
+#endif
+
+
+/* Initialization for the XCP Protocol Layer */
+extern void XcpInit(void);
+extern void XcpStart(void);
+extern void XcpDisconnect();
+
+/* XCP command processor */
+extern void XcpCommand( const uint32_t* pCommand, uint16_t len );
+
+/* Check status */
+extern BOOL XcpIsConnected();
+
+// Event list
+#ifdef XCP_ENABLE_DAQ_EVENT_LIST
+
+// Lookup event
+extern tXcpEvent* XcpGetEvent(uint16_t event);
+
+#endif
+
+
+/* Callbacks */
+extern BOOL ApplXcpConnect();
+extern BOOL ApplXcpPrepareDaq();
+extern BOOL ApplXcpStartDaq();
+extern void ApplXcpStopDaq();
+
+/* Generate a native pointer from XCP address extension and address */
+extern uint8_t* ApplXcpGetPointer(uint8_t addr_ext, uint32_t addr);
+extern uint32_t ApplXcpGetAddr(uint8_t* p);
+extern uint8_t *ApplXcpGetBaseAddr();
+
+/* DAQ clock */
+extern uint64_t ApplXcpGetClock64();
+extern uint8_t ApplXcpGetClockState();
+
+
+
+#if 0
+#pragma once
+/* xcpLite.h */
+
+/* Copyright(c) Vector Informatik GmbH.All rights reserved.
+   Licensed under the MIT license.See LICENSE file in the project root for details. */
+
+#include "xcp_cfg.h"    // Protocol layer configuration
+#include "xcptl_cfg.h"  // Transport layer configuration
+#include "xcp.h"        // XCP protocol defines
+#include "xcpTl.h"      // Transport layer interface
+
+
+
+/****************************************************************************/
+/* DAQ event information                                                    */
+/****************************************************************************/
+
+#ifdef XCP_ENABLE_DAQ_EVENT_LIST
+
+typedef struct {
+    const char* name;
+    uint32_t size; // ext event size
+    uint8_t timeUnit; // timeCycle unit, 1ns=0, 10ns=1, 100ns=2, 1us=3, ..., 1ms=6, ...
+    uint8_t timeCycle; // cycletime in units, 0 = sporadic or unknown
+    uint16_t sampleCount; // packed event sample count
+    uint16_t daqList; // associated DAQ list
+    uint8_t priority; // priority 0 = queued, 1 = pushing, 2 = realtime
+#ifdef XCP_ENABLE_MULTITHREAD_EVENTS
+    MUTEX mutex;
+#endif
+#ifdef XCP_ENABLE_TEST_CHECKS
+    uint64_t time; // last event time stamp
+#endif
+} tXcpEvent;
+
+#endif
+
+
+/****************************************************************************/
+/* Protocol layer interface                                                 */
+/****************************************************************************/
+
+/* Initialization for the XCP Protocol Layer */
+extern void XcpInit(void);
+extern void XcpStart(void);
+extern void XcpDisconnect();
+
+/* Trigger a XCP data acquisition or stimulation event */
+extern void XcpEvent(uint16_t event);
+extern void XcpEventExt(uint16_t event, uint8_t* base);
+extern void XcpEventAt(uint16_t event, uint64_t clock);
+
+/* XCP command processor */
+extern void XcpCommand( const uint32_t* pCommand, uint16_t len );
+
+/* Send an XCP event message */
+extern void XcpSendEvent(uint8_t evc, const uint8_t* d, uint8_t l);
+
+/* Check status */
+extern BOOL XcpIsStarted();
+extern BOOL XcpIsConnected();
+extern BOOL XcpIsDaqRunning();
+extern BOOL XcpIsDaqPacked();
+extern uint64_t XcpGetDaqStartTime();
+extern uint32_t XcpGetDaqOverflowCount();
+
+/* Time synchronisation */
+#ifdef XCP_ENABLE_DAQ_CLOCK_MULTICAST
+extern uint16_t XcpGetClusterId();
+#endif
+#ifdef XCP_ENABLE_PTP
+extern void XcpSetGrandmasterClockInfo(uint8_t* id, uint8_t epoch, uint8_t stratumLevel);
+#endif
+
+// Event list
+#ifdef XCP_ENABLE_DAQ_EVENT_LIST
+
+// Clear event list
+extern void XcpClearEventList();
+// Add a measurement event to event list, return event number (0..MAX_EVENT-1)
+extern uint16_t XcpCreateEvent(const char* name, uint32_t cycleTimeNs /* ns */, uint8_t priority /* 0-normal, >=1 realtime*/, uint16_t sampleCount, uint32_t size);
+// Get event list
+extern tXcpEvent* XcpGetEventList(uint16_t* eventCount);
+// Lookup event
+extern tXcpEvent* XcpGetEvent(uint16_t event);
+
+#endif
+
+
+/****************************************************************************/
+/* Protocol layer external dependencies                                     */
+/****************************************************************************/
+
+// All functions must be thread save
+
+/* Callbacks */
+extern BOOL ApplXcpConnect();
+extern BOOL ApplXcpPrepareDaq();
+extern BOOL ApplXcpStartDaq();
+extern void ApplXcpStopDaq();
+
+/* Generate a native pointer from XCP address extension and address */
+extern uint8_t* ApplXcpGetPointer(uint8_t addr_ext, uint32_t addr);
+extern uint32_t ApplXcpGetAddr(uint8_t* p);
+extern uint8_t *ApplXcpGetBaseAddr();
+
+/* Switch calibration page */
+#ifdef XCP_ENABLE_CAL_PAGE
+extern uint8_t ApplXcpGetCalPage(uint8_t segment, uint8_t mode);
+extern uint8_t ApplXcpSetCalPage(uint8_t segment, uint8_t page, uint8_t mode);
+#endif
+
+/* DAQ clock */
+extern uint64_t ApplXcpGetClock64();
+extern uint8_t ApplXcpGetClockState();
+#ifdef XCP_ENABLE_PTP
+extern BOOL ApplXcpGetClockInfoGrandmaster(uint8_t* uuid, uint8_t* epoch, uint8_t* stratum);
+#endif
+
+/* Info (for GET_ID) */
+extern uint32_t ApplXcpGetId(uint8_t id, uint8_t* buf, uint32_t bufLen);
+#ifdef XCP_ENABLE_IDT_A2L_UPLOAD // Enable GET_ID: A2L content upload to host
+extern BOOL ApplXcpReadA2L(uint8_t size, uint32_t addr, uint8_t* data);
+#endif
+
+#endif

--- a/Use_in_ECU/xcpTl.c
+++ b/Use_in_ECU/xcpTl.c
@@ -1,0 +1,325 @@
+/*----------------------------------------------------------------------------*/
+#include "main.h"
+#include "xcpTl.h"
+#include "xcptl_cfg.h"
+#include "xcpLite.h"
+/*----------------------------------------------------------------------------*/
+#define CAST( am_Type, am_Value )    ( ( am_Type )( am_Value ) )
+/*----------------------------------------------------------------------------*/
+#if ((XCPTL_MAX_CTO_SIZE&0x03) != 0)
+#error "XCPTL_MAX_CTO_SIZE should be aligned to 4!"
+#endif
+#if ((XCPTL_MAX_DTO_SIZE&0x03) != 0)
+#error "XCPTL_MAX_DTO_SIZE should be aligned to 4!"
+#endif
+/*----------------------------------------------------------------------------*/
+/**
+  @details
+  XCP on Ethernet Message (Frame) (see XCP_Book_V1.5_EN, page 57)
+
+  @details
+  XCP on Ethernet Message (Frame)
+  - XCP Header
+    - LEN == dlc
+    - CTR == ctr
+  - XCP Packet
+    - packet[1]
+  - XCP Tail
+    - packet before being copyed into this struct is extended with filler bytes. These filler bytes make the XCP Tail
+**/
+typedef struct {
+    uint8_t packet[1];  /**< message data **/
+} tXcpMessage;
+
+typedef struct {
+    uint8_t packet[XCPTL_MAX_CTO_SIZE];
+} tXcpCtoMessage;
+
+/**
+  @brief
+  Transmit Segment
+
+  @details
+  Transport Layer:
+  - segment = message 1 + message 2 ... + message n = concatenated transport layer messages
+  - message = len + ctr + (protocol layer packet) + fill (XCP_Book_V1.5_EN's XCP on Ethernet Message (Frame))
+**/
+typedef struct {
+    uint16_t uncommited;              /**< Number of uncommited messages in this segment **/
+    uint16_t size;                    /**< Number of overall bytes in this segment **/
+    uint8_t msg[XCPTL_SEGMENT_SIZE];  /**< Segment/MTU - concatenated transport layer messages **/
+} tXcpMessageBuffer;
+
+/**
+  @brief
+  Transport Layer instance
+
+  @details
+**/
+struct tXcpTlInstance {
+  tXcpMessageBuffer queue[XCPTL_QUEUE_SIZE]; /**< Transmit Segment Queue **/
+  uint32_t queue_rp;                         /**< Transmit Segment Queue's read index (next to read) **/
+  uint32_t queue_len;                        /**< Transmit Segment Queue's amount sendable/committable \n rp+len = write index (the next free entry), len=0 ist empty, len=XCPTL_QUEUE_SIZE is full **/
+  tXcpMessageBuffer* msg_ptr;                /**< current incomplete or not fully commited segment **/
+  uint16_t ctr;                              /**< next DAQ DTO data transmit message packet counter **/
+};
+
+/**
+  @brief
+  Transport Layer instance
+
+  @details
+**/
+static struct tXcpTlInstance gXcpTl;
+/*----------------------------------------------------------------------------*/
+#define CAN_RCVD    TRUE
+#define CAN_SENT    FALSE
+void
+DisplayCanTraffic( BOOL a_IsRcvd, uint8_t const a_Msg[], uint8_t a_Dlc )
+{
+  printf(
+    "CAN %s ECU: len = %d, data = %2x, %2x, %2x, %2x,   %2x, %2x, %2x, %2x\n",
+    ( a_IsRcvd ? "->" : "<-" ),
+    a_Dlc,
+    a_Msg[ 0 ], a_Msg[ 1 ], a_Msg[ 2 ], a_Msg[ 3 ],
+    a_Msg[ 4 ], a_Msg[ 5 ], a_Msg[ 6 ], a_Msg[ 7 ] );
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Transmit a UDP datagramm or TCP segment (contains multiple XCP DTO messages or a single CRM message (len+ctr+packet+fill))
+
+  @details
+  Must be thread safe, because it is called from CMD and from DAQ thread
+
+  @return
+  Returns -1 on would block, 1 if ok, 0 on error
+**/
+static int sendDatagram(const uint8_t *data, uint16_t size ) {
+  DisplayCanTraffic( CAN_SENT, data, size );
+
+  return 1;
+}
+/*----------------------------------------------------------------------------*/
+void XcpTlInit( void )
+{
+  gXcpTl.queue_rp = 0;
+  gXcpTl.queue_len = 0;
+  gXcpTl.msg_ptr = NULL;
+  gXcpTl.ctr = 0;
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Allocate a fresh segment in the queue
+
+  @details
+  Not thread save!
+**/
+static void getSegmentBuffer() {
+
+    tXcpMessageBuffer* b;
+
+    /* Check if there is space in the queue */
+    if (gXcpTl.queue_len >= XCPTL_QUEUE_SIZE) {
+        /* Queue overflow */
+        gXcpTl.msg_ptr = NULL;
+    }
+    else {
+        unsigned int i = gXcpTl.queue_rp + gXcpTl.queue_len;
+        if (i >= XCPTL_QUEUE_SIZE)
+        {
+          i -= XCPTL_QUEUE_SIZE;
+        }
+        b = &gXcpTl.queue[i];
+        b->size = 0;
+        b->uncommited = 0;
+        gXcpTl.msg_ptr = b;
+        gXcpTl.queue_len++;
+    }
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Reserve space for a XCP packet in a transmit buffer and return a pointer to packet data and a handle for the segment buffer for commit reference
+
+  @details
+  - reserve space for alignment (XCP Message's XCP Tail, see XCP_Book_V1.5_EN, page 57)
+  - if Packet does not fit anymore in current segment (msg_ptr->size + msg_size), get a fresh segment
+  - treat the segment as a @ref tXcpMessage
+  - update the ctr,dlc with the Packet's size
+**/
+uint8_t* XcpTlGetTransmitBuffer(void** handlep, uint16_t packet_size)
+{
+    tXcpMessage* p;
+    uint16_t msg_size;
+
+ #if XCPTL_PACKET_ALIGNMENT==2
+    packet_size = (uint16_t)((packet_size + 1) & 0xFFFE); // Add fill
+#endif
+#if XCPTL_PACKET_ALIGNMENT==4
+    packet_size = (uint16_t)((packet_size + 3) & 0xFFFC); // Add fill
+#endif
+    msg_size = (uint16_t)(packet_size + XCPTL_TRANSPORT_LAYER_HEADER_SIZE);
+
+    // Get another message buffer from queue, when active buffer ist full
+    // if ( ( gXcpTl.msg_ptr == NULL ) || ( (uint16_t)(gXcpTl.msg_ptr->size + msg_size) > XCPTL_SEGMENT_SIZE ) ) {
+    {
+        if( msg_size > XCPTL_SEGMENT_SIZE ) {
+            gXcpTl.msg_ptr = NULL;
+        }
+        else {
+            getSegmentBuffer();
+        }
+    }
+
+    if (gXcpTl.msg_ptr != NULL) {
+
+        p = (tXcpMessage*)&gXcpTl.msg_ptr->msg[gXcpTl.msg_ptr->size];
+        gXcpTl.msg_ptr->size = (uint16_t)(gXcpTl.msg_ptr->size + msg_size);
+        *((tXcpMessageBuffer**)handlep) = gXcpTl.msg_ptr;
+        gXcpTl.msg_ptr->uncommited++;
+
+    }
+    else {
+        p = NULL; // Overflow
+    }
+
+    if (p == NULL) return NULL; // Overflow
+    return &p->packet[0]; // return pointer to XCP message DTO data
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Protocol indicates that it copied the XCP Packet in the XCP Message (Frame)
+
+  @details
+  Mark the XCP Message as filled (committed)
+**/
+void XcpTlCommitTransmitBuffer(void* handle)
+{
+    tXcpMessageBuffer* p = (tXcpMessageBuffer*)handle;
+    if (handle != NULL) {
+        p->uncommited--;
+    }
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Mark current segment as filled and allocate a fresh segment
+**/
+void XcpTlFlushTransmitBuffer()
+{
+    if (gXcpTl.msg_ptr != NULL && gXcpTl.msg_ptr->size > 0) {
+        getSegmentBuffer();
+    }
+}
+/*----------------------------------------------------------------------------*/
+void XcpTlSendCrm(const uint8_t* packet, uint16_t packet_size)
+{
+#ifdef XCPTL_QUEUED_CRM
+
+    void* handle = NULL;
+    uint8_t* p;
+    int r = 0;
+
+    // If transmit queue is empty, save the space and transmit instantly
+    if (gXcpTl.queue_len < 1 && ( (gXcpTl.msg_ptr == NULL) || (gXcpTl.msg_ptr->size == 0))) {
+        // Send the response
+        // Build XCP CTO message (ctr+dlc+packet)
+        uint16_t msg_size;
+        msg_size = packet_size;
+#if (XCPTL_PACKET_ALIGNMENT==2)
+        msg_size = (uint16_t)((msg_size + 1) & 0xFFFE); // Add fill
+#endif
+#if (XCPTL_PACKET_ALIGNMENT==4)
+        msg_size = (uint16_t)((msg_size + 3) & 0xFFFC); // Add fill
+#endif
+        msg_size = (uint16_t)(msg_size + XCPTL_TRANSPORT_LAYER_HEADER_SIZE);
+        r = sendDatagram(packet, msg_size);
+    }
+    if (r == 1) return; // ok
+
+    // Queue the response packet
+    if ((p = XcpTlGetTransmitBuffer(&handle, packet_size)) != NULL) {
+        memcpy(p, packet, packet_size);
+        XcpTlCommitTransmitBuffer(handle);
+        XcpTlFlushTransmitBuffer();
+    }
+    else { // Buffer overflow
+        // @@@@ Todo
+    }
+
+#else
+  sendDatagram( data, n );
+#endif
+}
+/*----------------------------------------------------------------------------*/
+void XcpTlWaitForTransmitQueue()
+{
+    XcpTlFlushTransmitBuffer();
+#ifndef XCPTL_QUEUED_CRM
+    do {
+        sleepMs(2);
+    } while (gXcpTl.queue_len > 1) ;
+#endif
+}
+/*----------------------------------------------------------------------------*/
+void
+XcpTlCanReceive( uint8_t const a_Received[], uint8_t a_RcvdLen )
+{
+  DisplayCanTraffic( CAN_RCVD, a_Received, a_RcvdLen );
+  XcpCommand( CAST( uint32_t const *, a_Received ), a_RcvdLen );
+}
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Transmit all completed and fully commited UDP frames
+
+  @details
+  see @ref PAG_TransportLayer
+
+  @return
+  Returns 1 ok, 0 error
+**/
+static int XcpTlHandleTransmitQueue( void ) {
+  tXcpMessageBuffer* b;
+
+  for (;;) {
+    // Check
+    if (gXcpTl.queue_len >= 1) {
+      b = &gXcpTl.queue[gXcpTl.queue_rp];
+      if (b->uncommited > 0) b = NULL;
+    }
+    else {
+      b = NULL;
+    }
+    if (b == NULL) break;
+    if (b->size == 0)
+    {
+        if (++gXcpTl.queue_rp >= XCPTL_QUEUE_SIZE) gXcpTl.queue_rp = 0;
+        gXcpTl.queue_len--;
+        continue; // This should not happen @@@@
+    }
+
+    // Send this frame
+    int r = sendDatagram(&b->msg[0], b->size);
+    if (r == (-1)) return 1; // Ok, would block (-1)
+    if (r == 0) return 0; // Nok, error (0)
+
+    // Free this buffer when succesfully sent
+    if (++gXcpTl.queue_rp >= XCPTL_QUEUE_SIZE) gXcpTl.queue_rp = 0;
+    gXcpTl.queue_len--;
+  } // for (;;)
+
+  return 1; // Ok, queue empty now
+}
+/*----------------------------------------------------------------------------*/
+void XcpTlTransmitThreadCycle( void )
+{
+  if (gXcpTl.queue_len >= 1)
+  {
+    XcpTlHandleTransmitQueue();
+  }
+}
+/*----------------------------------------------------------------------------*/

--- a/Use_in_ECU/xcpTl.h
+++ b/Use_in_ECU/xcpTl.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+#ifndef XCP_TL_H
+#define XCP_TL_H
+/*----------------------------------------------------------------------------*/
+void XcpTlInit( void );
+void XcpTlCanReceive( uint8_t const a_Received[], uint8_t a_RcvdLen );
+
+extern uint8_t* XcpTlGetTransmitBuffer(void** handlep, uint16_t size); /**< Get a buffer for a message with size **/
+extern void XcpTlCommitTransmitBuffer(void* handle); /**< Commit a buffer from XcpTlGetTransmitBuffer **/
+extern void XcpTlFlushTransmitBuffer(); /**< Finalize the current transmit packet **/
+extern void XcpTlSendCrm(const uint8_t* packet, uint16_t packet_size); /**< Send or queue (depending on XCPTL_QUEUED_CRM) a command response **/
+extern void XcpTlWaitForTransmitQueue(); /**< Wait (sleep) until transmit queue is ready for immediate response **/
+
+void XcpTlTransmitThreadCycle( void );
+/*----------------------------------------------------------------------------*/
+#endif
+/*----------------------------------------------------------------------------*/

--- a/Use_in_ECU/xcp_cfg.h
+++ b/Use_in_ECU/xcp_cfg.h
@@ -1,0 +1,65 @@
+#pragma once
+
+/*----------------------------------------------------------------------------
+| File:
+|   xcp_cfg.h
+|
+| Description:
+|   User configuration file for XCP protocol layer parameters
+|
+| Code released into public domain, no attribution required
+|
+----------------------------------------------------------------------------*/
+
+
+ /*----------------------------------------------------------------------------*/
+ /* Platform specific type definitions for xcpLite.c */
+
+// Enable debug print (printf) depending on ApplXcpGetDebugLevel()
+#undef XCP_ENABLE_DEBUG_PRINTS
+
+// Enable extended error checks, performance penalty !!!
+#undef XCP_ENABLE_TEST_CHECKS
+
+#if 0
+XCP_CPUTYPE_BIGENDIAN
+XCP_DAQ_CLOCK_64BIT
+XCP_DAQ_MEM_SIZE
+XCP_ENABLE_CAL_PAGE
+XCP_ENABLE_CHECKSUM
+XCP_ENABLE_DAQ_CLOCK_MULTICAST
+XCP_ENABLE_DAQ_EVENT_INFO
+XCP_ENABLE_DAQ_EVENT_LIST
+XCP_ENABLE_DEBUG_PRINTS
+XCP_ENABLE_DYN_ADDRESSING
+XCP_ENABLE_IDT_A2L_HTTP_GET
+XCP_ENABLE_IDT_A2L_UPLOAD
+XCP_ENABLE_INTERLEAVED
+XCP_ENABLE_MULTITHREAD_EVENTS
+XCP_ENABLE_PACKED_MODE
+XCP_ENABLE_PTP
+XCP_ENABLE_TEST_CHECKS
+XCP_MAX_DTO_ENTRY_SIZE
+XCP_MAX_ODT_ENTRY_SIZE
+XCP_PROTOCOL_LAYER_VERSION
+XCPTL_MAX_CTO_SIZE
+XCPTL_MAX_DTO_SIZE
+XCPTL_QUEUED_CRM
+#endif
+ /*----------------------------------------------------------------------------*/
+ /* Version */
+
+// Driver version (GET_COMM_MODE_INFO)
+#define XCP_DRIVER_VERSION 0x01
+
+// Protocol layer version
+#define XCP_PROTOCOL_LAYER_VERSION 0x0104  // PACKED_MODE, CC_START_STOP_SYNCH prepare
+
+#define XCP_ENABLE_DAQ_EVENT_LIST // Enable event list
+#define XCP_MAX_EVENT 16 // Maximum number of events, size of event table
+
+#define XCP_DAQ_MEM_SIZE (5*200) // Amount of memory for DAQ tables, each ODT entry (e.g. measurement variable) needs 5 bytes
+
+#define XCP_TIMESTAMP_TICKS 1  // ticks per unit
+#define XCP_TIMESTAMP_UNIT DAQ_TIMESTAMP_UNIT_1US // unit DAQ_TIMESTAMP_UNIT_xxx
+#define XCP_DAQ_CLOCK_UIID { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 }

--- a/Use_in_ECU/xcptl_cfg.h
+++ b/Use_in_ECU/xcptl_cfg.h
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------*/
+#ifndef XCPTL_CFG_H
+#define XCPTL_CFG_H
+/*----------------------------------------------------------------------------*/
+/**
+  @brief
+  Transport layer version
+**/
+#define XCP_TRANSPORT_LAYER_VERSION 0x0104
+
+/**
+  @brief
+  Use transmit queue for command responses
+
+  @details
+**/
+#define XCPTL_QUEUED_CRM
+
+/**
+  @brief
+  CTO size
+  
+  @details
+  Maximum size of a XCP command
+**/
+#define XCPTL_MAX_CTO_SIZE 8 // must be mod 4
+
+
+  #define XCPTL_SEGMENT_SIZE 8
+  #define XCPTL_MAX_DTO_SIZE 8 // DTO size must be mod 4
+
+/**
+  @brief
+  DAQ transmit queue size
+
+  @details
+  Transmit queue size in segments, should at least be able to hold all data produced until the next call to HandleTransmitQueue
+**/
+#define XCPTL_QUEUE_SIZE (32)
+/**
+  @brief
+  Transport layer header size
+
+  @details
+  This is fixed, no other options supported
+**/
+#define XCPTL_TRANSPORT_LAYER_HEADER_SIZE 0
+/*----------------------------------------------------------------------------*/
+#endif
+/*----------------------------------------------------------------------------*/


### PR DESCRIPTION
- xcpTl.c/h implements XCP over CAN
- main.c implements a scenario (connect, short up, daq, disconnect) to show behavior of XCPlite
- xcpLite reused with modification:
  - avoid dependency on SOCKET from platform.h (could we split the networking part into a separate platform_networking.h?)
  - #error -> #warning, where does protocol assume CTO/DTO >= 16?
  - ApplXcpGetBaseAddr removed. Typical Win/Linux behavior should not be in protocol. Changed by ApplXcpGetPointer, this will increase run-time. Could we store the pointer from ApplXcpGetPointer instead of addr at the moment of XcpAddOdtEntry?
  - removed unused functions XcpEventAt and XcpEventExt  (avoid usage of ApplXcpGetBaseAddr)