### PR TITLE
fix typo in a2l file generation

### DIFF
--- a/src/A2L.c
+++ b/src/A2L.c
@@ -52,7 +52,7 @@ static const char* gA2lHeader =
 #if OPTION_ENABLE_CAL_SEGMENT
 static const char* gA2lMemorySegment =
 "/begin MEMORY_SEGMENT\n"
-"CALRAM \"\" DATA FLASH INTERN 0x%08X 0x%08X - 1 - 1 - 1 - 1 - 1\n" // CALRAM_START, CALRAM_SIZE
+"CALRAM \"\" DATA FLASH INTERN 0x%08X 0x%08X -1 -1 -1 -1 -1\n" // CALRAM_START, CALRAM_SIZE
 "/begin IF_DATA XCP\n"
 "/begin SEGMENT 0x01 0x02 0x00 0x00 0x00 \n"
 "/begin CHECKSUM XCP_ADD_44 MAX_BLOCK_SIZE 0xFFFF EXTERNAL_FUNCTION \"\" /end CHECKSUM\n"

--- a/src/A2L.cpp
+++ b/src/A2L.cpp
@@ -50,7 +50,7 @@ static const char* sHeader =
 static const char* sModPar = 
 "/begin MOD_PAR \"\"\n"
 "/begin MEMORY_SEGMENT\n"
-"CALRAM \"\" DATA FLASH INTERN 0x%08X 0x%08X - 1 - 1 - 1 - 1 - 1\n" // CALRAM_START, CALRAM_SIZE
+"CALRAM \"\" DATA FLASH INTERN 0x%08X 0x%08X -1 -1 -1 -1 -1\n" // CALRAM_START, CALRAM_SIZE
 "/begin IF_DATA XCP\n"
 "/begin SEGMENT 0x01 0x02 0x00 0x00 0x00 \n"
 "/begin CHECKSUM XCP_ADD_44 MAX_BLOCK_SIZE 0xFFFF EXTERNAL_FUNCTION \"\" /end CHECKSUM\n"


### PR DESCRIPTION
It looks like there is a typo in the a2l file generation

This generates invalid a2l files which are rejected by more strict a2lfile implementation

e.g. https://github.com/DanielT/a2lfile