### PR TITLE
Use memcpy for XcpWrite/ReadMta

### DIFF
--- a/src/xcpLite.c
+++ b/src/xcpLite.c
@@ -360,12 +360,7 @@ static uint8_t XcpWriteMta( uint8_t size, const uint8_t* data )
     // Ext=0x00 Standard memory access
     if (gXcp.MtaExt == 0x00) {
         if (gXcp.MtaPtr == NULL) return CRC_ACCESS_DENIED;
-        while (size > 0) {
-            *gXcp.MtaPtr = *data;
-            gXcp.MtaPtr++;
-            data++;
-            size--;
-        }
+        memcpy(gXcp.MtaPtr, data, size);
         return 0; // Ok
     }
 
@@ -394,12 +389,7 @@ static uint8_t XcpReadMta( uint8_t size, uint8_t* data )
     // Ext=0x00 Standard memory access
     if (gXcp.MtaExt == 0x00) {
         if (gXcp.MtaPtr == NULL) return CRC_ACCESS_DENIED;
-        while (size > 0) {
-            *data = *gXcp.MtaPtr;
-            data++;
-            gXcp.MtaPtr++;
-            size--;
-        }
+        memcpy(data, gXcp.MtaPtr, size);
         return 0; // Ok
     }
 


### PR DESCRIPTION
It seems pointless using while loop to write and read MTA data byte by byte, which can be fully replaced by a memcpy