### PR TITLE
Update 'gXcp.MtaPtr' in XcpReadMta() and XcpWriteMta().

### DIFF
--- a/src/xcpLite.c
+++ b/src/xcpLite.c
@@ -372,13 +372,14 @@ static uint8_t XcpWriteMta( uint8_t size, const uint8_t* data )
     if (gXcp.MtaExt == 0x00) {
         if (gXcp.MtaPtr == NULL) return CRC_ACCESS_DENIED;
         memcpy(gXcp.MtaPtr, data, size);
+        gXcp.MtaPtr += size;
         return 0; // Ok
     }
 
     return CRC_ACCESS_DENIED; // Access violation
 }
 
-// Read n bytes. Copying of size bytes from data to gXcp.MtaPtr
+// Read n bytes. Copying of size bytes from gXcp.MtaPtr to data
 static uint8_t XcpReadMta( uint8_t size, uint8_t* data )
 {
     // Ext=0x01 Relativ addressing
@@ -401,6 +402,7 @@ static uint8_t XcpReadMta( uint8_t size, uint8_t* data )
     if (gXcp.MtaExt == 0x00) {
         if (gXcp.MtaPtr == NULL) return CRC_ACCESS_DENIED;
         memcpy(data, gXcp.MtaPtr, size);
+        gXcp.MtaPtr += size;
         return 0; // Ok
     }
 


### PR DESCRIPTION
Bug was introduced in V5.4 with commit 832e0da.
In case of multiple consecutive CC_UPLOAD requests from CANape, XcpReadMta() has to update 'gXcp.MtaPtr'.
An example sequence sent by CANape would be: CC_SET_MTA -> CC_UPLOAD -> CC_UPLOAD.
This sequence is, for instace, triggered when using a calibration map (2D-array) in CANape, and we connect to the ECU which is the XCP-slave. Now if 'gXcp.MtaPtr' is not updated, the same data from the ECU is sent in each response to a consecutive CC_UPLOAD, and hence the map's displayed values in CANape will be repeated - the wrong values are displayed.

In case of multiple consecutive CC_DOWNLOAD requests from CANape, XcpWriteMta() has to update 'gXcp.MtaPtr'.
An example sequence sent by CANape would be: CC_SET_MTA -> CC_DOWNLOAD -> CC_DOWNLOAD.
Also corrected comment above XcpReadMta().