### PR TITLE
Fix flaky server shutdown mechanism

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -72,6 +72,7 @@ typedef HANDLE tXcpThread;
 #define create_thread(h,t) *h = CreateThread(0, 0, t, NULL, 0, NULL)
 #define join_thread(h) WaitForSingleObject(h, INFINITE);
 #define terminate_thread(h) { TerminateThread(h,0); WaitForSingleObject(h,1000); CloseHandle(h); }
+#define cancel_thread terminate_thread
 
 #elif defined(_LINUX) // Linux
 
@@ -79,6 +80,7 @@ typedef pthread_t tXcpThread;
 #define create_thread(h,t) pthread_create(h, NULL, t, NULL);
 #define join_thread(h) pthread_join(h,NULL);
 #define detach_thread(h) { pthread_detach(h); pthread_cancel(h); }
+#define cancel_thread detach_thread
 
 #endif
 

--- a/src/xcpEthServer.c
+++ b/src/xcpEthServer.c
@@ -92,6 +92,7 @@ BOOL XcpEthServerShutdown() {
         XcpTlShutdown();
         gXcpServer.isInit = FALSE;
         socketCleanup();
+        XcpReset();
     }
     return TRUE;
 }

--- a/src/xcpEthServer.c
+++ b/src/xcpEthServer.c
@@ -86,11 +86,10 @@ BOOL XcpEthServerShutdown() {
 
     if (gXcpServer.isInit) {
         XcpDisconnect();
-        gXcpServer.ReceiveThreadRunning = FALSE;
-        gXcpServer.TransmitThreadRunning = FALSE;
+        cancel_thread(gXcpServer.ReceiveThreadHandle);
+        cancel_thread(gXcpServer.TransmitThreadHandle);
+
         XcpTlShutdown();
-        join_thread(gXcpServer.ReceiveThreadHandle);
-        join_thread(gXcpServer.TransmitThreadHandle);
         gXcpServer.isInit = FALSE;
         socketCleanup();
     }

--- a/src/xcpLite.c
+++ b/src/xcpLite.c
@@ -857,6 +857,11 @@ void XcpDisconnect( void )
   gXcp.SessionStatus &= (uint16_t)(~SS_CONNECTED);
 }
 
+// Reset XCP kernel states
+void XcpReset() {
+    memset(&gXcp, 0, sizeof(gXcp));
+}
+
 // Transmit command response
 static void XcpSendResponse() {
 

--- a/src/xcpLite.h
+++ b/src/xcpLite.h
@@ -73,6 +73,7 @@ typedef struct {
 extern void XcpInit(void);
 extern void XcpStart(void);
 extern void XcpDisconnect();
+extern void XcpReset();
 
 /* Trigger a XCP data acquisition or stimulation event */
 extern void XcpEvent(uint16_t event);


### PR DESCRIPTION
### What?

* Define cancel_thread based on terminate_thread (win) and detach_thread (linux)
* Use cancel_thread for server shutdown
* Impl XcpReset to reset XCP status when server is shutdown

### Why?

* Calling join_thread will shutdown server, but also crashes the program
* Calling join_thread/terminate_thread/detach_thread after XcpTlShutdown also crashes the program
* Using terminat_thread and detach_thread mechanism will shutdown the server only passively. But so long as the server receives a msg from a master, it can then shutdown normally
* If XCP session status is not reset after shutdown, then it will act flaky when reinitialized