### PR TITLE
Support static allocation and improve FreeRTOS robustness

### DIFF
--- a/examples/freertos_demo/README.md
+++ b/examples/freertos_demo/README.md
@@ -61,7 +61,7 @@ xcplite_sources = [
 
 The FreeRTOS build of XCPlite:
 - Uses the FreeRTOS/lwIP socket, thread, mutex and clock platform abstractions in `src/platform.c`.
-- Uses the mutex-based 32-bit queue implementation in `src/queue32.c` or the critical-section-based variant `src/queue32m.c`.
+- Uses `src/queue32m.c` with mutex or critical-section synchronization.
 
 
 ### Key files in the xcplite source tree

--- a/examples/freertos_demo/README.md
+++ b/examples/freertos_demo/README.md
@@ -218,10 +218,11 @@ Init transport layer queue (queue32)
   buffer_size=23680, queue_size=16 (23680 Bytes)
 ```
 
-The 32-bit transmit queue used for FreeRTOS has a fixed, statically allocated buffer (`queue32m.c`). Its size is derived from `OPTION_QUEUE_32_SEGMENT_COUNT`.
-There are no heap allocations in the 32-bit FreeRTOS build.
+`queue32m.c` uses a fixed, statically allocated transmit queue sized by `OPTION_QUEUE_32_SEGMENT_COUNT`. It does not use the heap.
 
-Each queue segment provides storage for up to one UDP payload plus 8 bytes of internal metadata. With the default MTU of 1500, each segment occupies 1480 bytes and the default 16 segments consume 23,680 bytes of static RAM. Increase `OPTION_QUEUE_32_SEGMENT_COUNT` if packets are dropped during DAQ bursts, or decrease it to reduce static RAM usage.
+With `configSUPPORT_STATIC_ALLOCATION=1`, XCPlite also uses static storage for its FreeRTOS mutexes, internal task control blocks and stacks. Otherwise, it uses the dynamic FreeRTOS creation APIs. This setting does not affect application- or kernel-owned objects.
+
+Each segment holds one UDP payload plus 8 bytes of metadata. With the default MTU of 1500, each segment occupies 1,480 bytes, so 16 segments require 23,680 bytes of static RAM. Adjust `OPTION_QUEUE_32_SEGMENT_COUNT` for DAQ burst capacity and RAM usage.
 
 The queue state and buffer use the default `.dtcm` and `.noncacheable` sections on embedded targets. These sections may be overridden in `xcplib_rtos_cfg.h` to match the application linker script:
 
@@ -470,8 +471,9 @@ from an ISR or from a high-priority FreeRTOS task.
 ## Notes
 
 - Calibration is lock-free and based on atomics.
-- The data acquisition queue is protected by a mutex.
-- XCP creates two tasks/threads for RX and TX.
+- `queue32m.c` uses a FreeRTOS critical section by default; define `OPTION_QUEUE32_MUTEX` to use a mutex.
+- The built-in server creates RX and TX tasks. Their control blocks and stacks are static when `configSUPPORT_STATIC_ALLOCATION=1`.
+- `vTaskDelete()` supports static tasks; it removes the task without freeing its static control block or stack.
 
 
 
@@ -484,7 +486,6 @@ from an ISR or from a high-priority FreeRTOS task.
 - xcpclient error message when .aml not found
 - Support for A2L generation of arrays
 - Disable the automatic GET_ID and try A2L upload in xcpclient
-- Check if the mutex-based queue is acceptable or if we should port one of the lockless queue implementations based on 64-bit atomic head and tail
 - Add TCP support
 - Do some benchmarking on CPU load, event trigger and calibration RCU latency
 - Avoid copying the transmit buffers

--- a/examples/freertos_demo/xcp_demo.c
+++ b/examples/freertos_demo/xcp_demo.c
@@ -1,6 +1,7 @@
 // XCP FreeRTOS demo application
 
 #include "assert.h"
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -360,13 +361,14 @@ static void test(void) {
 
         // Check timestamp resolution and XCP clock
         for (int i = 0; i < 20; i++) {
-            void Clock64_Update(void);
+#if !defined(FREE_RTOS_POSIX_SIM)
             Clock64_Update();
+#endif
 
             uint64_t t1 = ApplXcpGetClock64();
             vTaskDelay(pdMS_TO_TICKS(1000));
             uint64_t t2 = ApplXcpGetClock64();
-            printf("XCP clock resolution check: t1=%llu, t2=%llu, dt=%llu\n", t1, t2, t2 - t1);
+            printf("XCP clock resolution check: t1=%" PRIu64 ", t2=%" PRIu64 ", dt=%" PRIu64 "\n", t1, t2, t2 - t1);
         }
     } else {
         printf("Scheduler not running, skipping XCP clock check\n");

--- a/src/platform.c
+++ b/src/platform.c
@@ -86,13 +86,16 @@ int _kbhit(void) {
 #if defined(_FREE_RTOS) // FreeRTOS sleep
 
 // Minimum granularity is one tick (1 ms at configTICK_RATE_HZ = 1000).
-// Sub-millisecond delays are rounded up to the next tick.
+// Delays are rounded up to the next tick.
 void sleepUs(uint32_t us) {
-    TickType_t ticks = (us * configTICK_RATE_HZ) / 1000000UL;
+    TickType_t ticks = (TickType_t)((((uint64_t)us * configTICK_RATE_HZ) + 999999U) / 1000000U);
     vTaskDelay(ticks == 0U ? 1U : ticks);
 }
 
-void sleepMs(uint32_t ms) { vTaskDelay(pdMS_TO_TICKS(ms == 0U ? 1U : ms)); }
+void sleepMs(uint32_t ms) {
+    TickType_t ticks = (TickType_t)((((uint64_t)ms * configTICK_RATE_HZ) + 999U) / 1000U);
+    vTaskDelay(ticks == 0U ? 1U : ticks);
+}
 
 #elif defined(_WIN) // Windows
 

--- a/src/platform.c
+++ b/src/platform.c
@@ -375,16 +375,24 @@ void mutexInit(MUTEX *m, bool recursive, uint32_t spinCount) {
     (void)spinCount;
 #if configUSE_RECURSIVE_MUTEXES == 1
     m->recursive = recursive;
+#if configSUPPORT_STATIC_ALLOCATION == 1
+    m->handle = recursive ? xSemaphoreCreateRecursiveMutexStatic(&m->buffer) : xSemaphoreCreateMutexStatic(&m->buffer);
+#else
     m->handle = recursive ? xSemaphoreCreateRecursiveMutex() : xSemaphoreCreateMutex();
+#endif
 #else
     if (recursive) {
         m->handle = NULL;
         assert(!recursive); // Recursive FreeRTOS mutexes are disabled in this configuration
         return;
     }
+#if configSUPPORT_STATIC_ALLOCATION == 1
+    m->handle = xSemaphoreCreateMutexStatic(&m->buffer);
+#else
     m->handle = xSemaphoreCreateMutex();
 #endif
-    assert(m->handle != NULL); // heap exhausted – increase configTOTAL_HEAP_SIZE
+#endif
+    assert(m->handle != NULL); // Check mutex creation
 }
 
 void mutexDestroy(MUTEX *m) {

--- a/src/platform.c
+++ b/src/platform.c
@@ -536,7 +536,7 @@ bool socketBind(SOCKET_HANDLE socket, const uint8_t *addr, uint16_t port) {
     a.sin_family = AF_INET;
     a.sin_port = htons(port);
     if (addr != NULL && addr[0] != 0) {
-        a.sin_addr.s_addr = *(uint32_t *)addr;
+        memcpy(&a.sin_addr.s_addr, addr, sizeof(a.sin_addr.s_addr));
     } else {
         a.sin_addr.s_addr = htonl(INADDR_ANY);
     }
@@ -626,7 +626,7 @@ int16_t socketSendTo(SOCKET_HANDLE socket, const uint8_t *buffer, uint16_t buffe
     memset(&dst, 0, sizeof(dst));
     dst.sin_family = AF_INET;
     dst.sin_port = htons(port);
-    dst.sin_addr.s_addr = *(uint32_t *)addr;
+    memcpy(&dst.sin_addr.s_addr, addr, sizeof(dst.sin_addr.s_addr));
     if (time != NULL) {
         *time = clockGet(); // No hardware timestamps on lwIP; use XCP clock at send time
     }

--- a/src/platform.h
+++ b/src/platform.h
@@ -312,13 +312,16 @@ void platformShmUnlink(const char *name);
 
 typedef struct {
     SemaphoreHandle_t handle;
+#if configSUPPORT_STATIC_ALLOCATION == 1
+    StaticSemaphore_t buffer; // Static storage for the FreeRTOS mutex
+#endif
 #if configUSE_RECURSIVE_MUTEXES == 1
     bool recursive;
 #endif
 } MUTEX;
 
-#if configUSE_RECURSIVE_MUTEXES == 1
-#define MUTEX_INTIALIZER {NULL, false}
+#ifdef __cplusplus
+#define MUTEX_INTIALIZER {}
 #else
 #define MUTEX_INTIALIZER {NULL}
 #endif
@@ -373,17 +376,29 @@ typedef HANDLE THREAD_HANDLE;
 #define OPTION_FREERTOS_PRIORITY (tskIDLE_PRIORITY + 2U)
 #endif
 
-typedef TaskHandle_t THREAD_HANDLE;
 #if defined(ESP_PLATFORM)
 #define FREERTOS_TASK_STACK_DEPTH(stack_bytes) (stack_bytes)
 #else
 #define FREERTOS_TASK_STACK_DEPTH(stack_bytes) ((stack_bytes) / sizeof(StackType_t))
 #endif
+
+typedef TaskHandle_t THREAD_HANDLE;
+#if configSUPPORT_STATIC_ALLOCATION == 1
+// Each call site owns a persistent task control block and stack.
+#define create_thread(h, _attr, fn, args)                                                                                                                                          \
+    do {                                                                                                                                                                           \
+        static StaticTask_t task_buffer;                                                                                                                                           \
+        static StackType_t stack_buffer[FREERTOS_TASK_STACK_DEPTH(OPTION_FREERTOS_STACK_BYTES)];                                                                                  \
+        *(h) = xTaskCreateStatic((TaskFunction_t)(fn), #fn, FREERTOS_TASK_STACK_DEPTH(OPTION_FREERTOS_STACK_BYTES), (args), OPTION_FREERTOS_PRIORITY, stack_buffer, &task_buffer); \
+        assert(*(h) != NULL);                                                                                                                                                      \
+    } while (0)
+#else
 #define create_thread(h, _attr, fn, args)                                                                                                                                          \
     do {                                                                                                                                                                           \
         BaseType_t res = xTaskCreate((TaskFunction_t)(fn), #fn, FREERTOS_TASK_STACK_DEPTH(OPTION_FREERTOS_STACK_BYTES), (args), OPTION_FREERTOS_PRIORITY, (h));                    \
         assert(res == pdPASS);                                                                                                                                                     \
     } while (0)
+#endif
 #define join_thread(h) /* No blocking join in FreeRTOS; synchronize via event flag or semaphore */
 #define cancel_thread(h) vTaskDelete(h)
 #define get_thread_id() ((uint32_t)(uintptr_t)xTaskGetCurrentTaskHandle())

--- a/src/queue32m.c
+++ b/src/queue32m.c
@@ -13,14 +13,6 @@
 |
  ----------------------------------------------------------------------------*/
 
-/*
-
-@@@@ TODO:
-
-
-3. Power-of-2 segment count → replace modulo with AND
-*/
-
 #include "platform.h"   // for platform abstraction
 #include "xcplib_cfg.h" // for OPTION_xxx
 

--- a/src/queue32m.c
+++ b/src/queue32m.c
@@ -350,12 +350,17 @@ void queuePush(tQueueHandle _queue_handle, const tQueueBuffer *queue_buffer, boo
 // This function is thread safe, any thread can ask for the queue level
 // Not used by the queue implementation itself
 uint32_t queueLevel(tQueueHandle _queue_handle, uint32_t *queue_max_level) {
+    uint32_t level = 0;
+
+    LOCK;
     if (queue_max_level != NULL)
         *queue_max_level = sXcpQueue.queue_size;
     if (sXcpQueue.queue_len > 1 || (sXcpQueue.queue_len == 1 && sXcpQueue.msg_ptr != NULL && sXcpQueue.msg_ptr->size > 0)) {
-        return sXcpQueue.queue_len;
+        level = sXcpQueue.queue_len;
     }
-    return 0;
+    UNLOCK;
+
+    return level;
 }
 
 // Check if there is a message segment in the transmit queue
@@ -369,6 +374,8 @@ tQueueBuffer queuePop(tQueueHandle _queue_handle, bool accumulate, bool flush, u
 
     tXcpSegmentBuffer *b = NULL;
 
+    LOCK;
+
     // Return the number of packets lost since the last call to queuePop
     if (packets_lost != NULL) {
         *packets_lost = sXcpQueue.packets_lost;
@@ -376,8 +383,6 @@ tQueueBuffer queuePop(tQueueHandle _queue_handle, bool accumulate, bool flush, u
     }
 
     // Check if there is a message segment ready in the transmit queue
-    LOCK;
-
     if (sXcpQueue.queue_len >= 1) {
 
         b = &sXcpQueue.queue[sXcpQueue.queue_rp];

--- a/src/xcplib_rtos_cfg.h
+++ b/src/xcplib_rtos_cfg.h
@@ -52,7 +52,7 @@
 #define OPTION_FREERTOS_PRIORITY (tskIDLE_PRIORITY + 2U)
 
 // FreeRTOS IP stack configuration
-#define OPTION_FREERTOS_LWIP // Use the lwIP stack for FreeRTOS; requires FreeRTOS+TCP
+#define OPTION_FREERTOS_LWIP // Use the lwIP socket API for FreeRTOS
 
 //-------------------------------------------------------------------------------
 // Logging


### PR DESCRIPTION
## Summary

Add optional static allocation for XCPlite's internal FreeRTOS tasks and mutexes.

When `configSUPPORT_STATIC_ALLOCATION` is enabled, XCPlite uses persistent task stacks, task control blocks and semaphore storage. When disabled, the existing dynamic FreeRTOS APIs remain in use.

## Changes

- Support static allocation for internal FreeRTOS tasks.
- Support static allocation for regular and recursive FreeRTOS mutexes.
- Preserve dynamic allocation when static allocation is disabled.
- Fix FreeRTOS delay rounding and prevent overflow during tick conversion.
- Avoid potentially unaligned and aliasing-unsafe IPv4 address access in the lwIP socket implementation.
- Fix data races in `queue32m` by protecting the `queueLevel()` snapshot and `packets_lost` read/reset with the existing `LOCK`/`UNLOCK` mechanism.
- Fix the FreeRTOS POSIX emulator clock-test build and use portable `uint64_t` formatting.
- Clarify FreeRTOS queue, allocation and lwIP documentation.

## Validation

- Built the default XCPlite configuration and test suite.
- Built the FreeRTOS library with static and dynamic allocation.
- Tested regular mutex, recursive mutex and critical-section configurations.
- Built and ran the FreeRTOS POSIX emulator with recursive mutexes disabled and enabled.
- Verified UDP startup, RX/TX task creation and shutdown.
- Reproduced the original `queue32m` data races with ThreadSanitizer; the updated implementation completed without warnings in both mutex and critical-section configurations.
- Compiled the FreeRTOS/lwIP socket path with strict alignment and aliasing warnings enabled.
