### PR TITLE
Fix DAQ configuration validation and event linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Switching compilers requires a fresh build directory (CMake caches the compiler 
 
 ### Running tests
 
-Tests are plain executables built under `XCPLITE_BUILD_TESTS=ON` (default config: `a2l_test`, `cal_test`, `daq_test`, `clock_test`, `queue_test`, `xcp_test`, `type_detection_test_*`; `ptp` config: `clock_test` only). Build then run directly, e.g.:
+Tests are plain executables built under `XCPLITE_BUILD_TESTS=ON` (default config: `a2l_test`, `cal_test`, `daq_test`, `daq_config_test`, `clock_test`, `queue_test`, `xcp_test`, `type_detection_test_*`; `ptp` config: `clock_test` only). Build then run directly, e.g.:
 
 ```bash
 ./build.sh tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 #                external_example is also a standalone project; see examples/external_example/
 #     rtos     -> freertos_demo (downloads FreeRTOS-Kernel via FetchContent)
 #   XCPLITE_BUILD_TESTS
-#     default  -> a2l_test, cal_test, daq_test, clock_test, queue_test, type_detection_test_*
+#     default  -> a2l_test, cal_test, daq_test, daq_config_test, clock_test, queue_test, type_detection_test_*
 #     ptp      -> clock_test
 #     others   -> (none)
 #   XCPLITE_BUILD_TOOLS
@@ -354,6 +354,9 @@ if(XCPLITE_BUILD_TESTS)
 
         add_executable(daq_test test/daq_test/src/main.c)
         target_link_libraries(daq_test PRIVATE xcplite)
+
+        add_executable(daq_config_test test/daq_config_test/src/main.c test/daq_config_test/src/xcptl_stub.c)
+        target_link_libraries(daq_config_test PRIVATE xcplite)
 
         add_executable(clock_test test/clock_test/src/main.cpp)
         target_link_libraries(clock_test PRIVATE xcplite)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -40,7 +40,7 @@ Within a chosen configuration, the following options control what gets built:
 
 | Configuration | Examples (`BUILD_EXAMPLES`) | Tests (`BUILD_TESTS`) | Tools (`BUILD_TOOLS`) |
 |---------------|-----------------------------|-----------------------|-----------------------|
-| `default` | hello_xcp, hello_xcp_cpp, c_demo, cpp_demo, point_cloud_demo, struct_demo, multi_thread_demo, ptp4l_demo¹, bpf_demo¹² | a2l_test, cal_test, daq_test, clock_test, queue_test, xcp_test, type_detection_test_* | *(none)* |
+| `default` | hello_xcp, hello_xcp_cpp, c_demo, cpp_demo, point_cloud_demo, struct_demo, multi_thread_demo, ptp4l_demo¹, bpf_demo¹² | a2l_test, cal_test, daq_test, daq_config_test, clock_test, queue_test, xcp_test, type_detection_test_* | *(none)* |
 | `no_a2l` | no_a2l_demo, no_a2l_demo_cpp | *(none)* | *(none)* |
 | `ptp` | ptp4l_demo¹ | clock_test | ptptool¹ |
 | `shm` | hello_xcp (SHM), hello_xcp_cpp (SHM) | *(none)* | shmtool, xcpdaemon³ |

--- a/src/xcplite.c
+++ b/src/xcplite.c
@@ -1107,9 +1107,9 @@ static void XcpClearDaq(void) {
 #endif
 }
 
-// Check if there is sufficient memory for the values of DaqCount, OdtCount and OdtEntryCount
+// Check if there is sufficient memory for the given DAQ, ODT and ODT entry counts
 // Return CRC_MEMORY_OVERFLOW if not
-static uint8_t XcpCheckMemory(void) {
+static uint8_t XcpCheckMemory(uint16_t daqCount, uint16_t odtCount, uint16_t odtEntryCount) {
 
     uint32_t s;
 
@@ -1120,8 +1120,7 @@ static uint8_t XcpCheckMemory(void) {
 #endif
 
     /* Check memory overflow */
-    s = (shared.daq_lists.daq_count * (uint32_t)sizeof(tXcpDaqList)) + (shared.daq_lists.odt_count * (uint32_t)sizeof(tXcpOdt)) +
-        (shared.daq_lists.odt_entry_count * ODT_ENTRY_SIZE);
+    s = (daqCount * (uint32_t)sizeof(tXcpDaqList)) + (odtCount * (uint32_t)sizeof(tXcpOdt)) + (odtEntryCount * ODT_ENTRY_SIZE);
     if (s >= XCP_DAQ_MEM_SIZE) {
         DBG_PRINTF_ERROR("DAQ memory overflow, %u of %u Bytes required\n", s, XCP_DAQ_MEM_SIZE);
         return CRC_MEMORY_OVERFLOW;
@@ -1141,18 +1140,17 @@ static uint8_t XcpCheckMemory(void) {
 // Allocate daqCount DAQ lists
 static uint8_t XcpAllocDaq(uint16_t daqCount) {
 
-    uint16_t daq;
-    uint8_t r;
-
     if (shared.daq_lists.odt_count != 0 || shared.daq_lists.odt_entry_count != 0)
         return CRC_SEQUENCE;
     if (daqCount == 0)
         return CRC_OUT_OF_RANGE;
 
+    uint8_t r = XcpCheckMemory(daqCount, shared.daq_lists.odt_count, shared.daq_lists.odt_entry_count);
+    if (r != 0)
+        return r;
+
     // Initialize
-    if (0 != (r = XcpCheckMemory()))
-        return r; // Memory overflow
-    for (daq = 0; daq < daqCount; daq++) {
+    for (uint16_t daq = 0; daq < daqCount; daq++) {
         DaqListEventChannelMut(daq) = XCP_UNDEFINED_EVENT_ID;
         DaqListAddrExtMut(daq) = XCP_UNDEFINED_ADDR_EXT;
 #ifdef XCP_MAX_EVENT_COUNT
@@ -1185,17 +1183,21 @@ static uint8_t XcpAllocOdt(uint16_t daq, uint8_t odtCount) {
     n = (uint32_t)shared.daq_lists.odt_count + (uint32_t)odtCount;
     if (n > 0xFFFF)
         return CRC_OUT_OF_RANGE; // Overall number of ODTs limited to 64K
+
+    uint8_t r = XcpCheckMemory(shared.daq_lists.daq_count, (uint16_t)n, shared.daq_lists.odt_entry_count);
+    if (r != 0)
+        return r;
+
     shared_mut.daq_lists.u.daq_list[daq].first_odt = shared.daq_lists.odt_count;
     shared_mut.daq_lists.odt_count = (uint16_t)n;
     shared_mut.daq_lists.u.daq_list[daq].last_odt = (uint16_t)(shared.daq_lists.odt_count - 1);
-    return XcpCheckMemory();
+    return 0;
 }
 
 // Increase current ODT size (absolute ODT index) size by n
 static bool XcpAdjustOdtSize(uint16_t daq, uint16_t odt, uint8_t n) {
 
     uint16_t size = (uint16_t)(DaqListOdtTable[odt].size + n);
-    DaqListOdtTableMut[odt].size = size;
 
 #ifdef XCP_ENABLE_TEST_CHECKS
     assert(odt >= DaqListFirstOdt(daq));
@@ -1208,6 +1210,7 @@ static bool XcpAdjustOdtSize(uint16_t daq, uint16_t odt, uint8_t n) {
 #else
     (void)daq;
 #endif
+    DaqListOdtTableMut[odt].size = size;
     return true;
 }
 
@@ -1221,7 +1224,7 @@ static uint8_t XcpAllocOdtEntry(uint16_t daq, uint8_t odt, uint8_t odtEntryCount
         return CRC_DAQ_CONFIG;
     if (shared.daq_lists.daq_count == 0 || shared.daq_lists.odt_count == 0)
         return CRC_SEQUENCE;
-    if (daq >= shared.daq_lists.daq_count || odtEntryCount == 0 || odt >= DaqListOdtCount(daq))
+    if (daq >= shared.daq_lists.daq_count || odt >= DaqListOdtCount(daq))
         return CRC_OUT_OF_RANGE;
 
     /* Absolute ODT entry count is limited to 64K */
@@ -1229,12 +1232,16 @@ static uint8_t XcpAllocOdtEntry(uint16_t daq, uint8_t odt, uint8_t odtEntryCount
     if (n > 0xFFFF)
         return CRC_MEMORY_OVERFLOW;
 
+    uint8_t r = XcpCheckMemory(shared.daq_lists.daq_count, shared.daq_lists.odt_count, (uint16_t)n);
+    if (r != 0)
+        return r;
+
     xcpFirstOdt = shared.daq_lists.u.daq_list[daq].first_odt;
     DaqListOdtTableMut[xcpFirstOdt + odt].first_odt_entry = shared.daq_lists.odt_entry_count;
     shared_mut.daq_lists.odt_entry_count = (uint16_t)n;
     DaqListOdtTableMut[xcpFirstOdt + odt].last_odt_entry = (uint16_t)(shared.daq_lists.odt_entry_count - 1);
     DaqListOdtTableMut[xcpFirstOdt + odt].size = 0;
-    return XcpCheckMemory();
+    return 0;
 }
 
 // Set ODT entry pointer
@@ -1279,21 +1286,20 @@ static uint8_t XcpAddOdtEntry(uint32_t addr, uint8_t ext, uint8_t size) {
         DBG_PRINTF_ERROR("DAQ list must have unique address extension, DAQ=%u, ODT=%u, ext=%u, daq_ext=%u\n", local.write_daq_daq, local.write_daq_odt, ext, daq_ext);
         return CRC_DAQ_CONFIG; // Error not unique address extension
     }
-    DaqListAddrExtMut(local.write_daq_daq) = ext;
 #endif
 
     uint32_t base_offset = 0;
 #ifdef XCP_ENABLE_DYN_ADDRESSING
+    uint16_t event = XCP_UNDEFINED_EVENT_ID;
     // DYN addressing mode, base pointer will given to XcpEventExt, event is encoded in the address
     if (XcpAddrIsDyn(ext)) {
-        uint16_t event = XcpAddrDecodeDynEvent(addr);
+        event = XcpAddrDecodeDynEvent(addr);
         base_offset = XcpAddrDecodeDynOffset(addr);
         uint16_t e0 = DaqListEventChannel(local.write_daq_daq);
         if (e0 != XCP_UNDEFINED_EVENT_ID && e0 != event) {
             DBG_PRINTF_ERROR("DAQ list must have unique event channel, DAQ=%u, ODT=%u, event=%u, DaqListEventChannel=%u\n", local.write_daq_daq, local.write_daq_odt, event, e0);
             return CRC_OUT_OF_RANGE; // Error event channel redefinition
         }
-        DaqListEventChannelMut(local_mut.write_daq_daq) = event;
     } else
 #endif
 #ifdef XCP_ENABLE_REL_ADDRESSING
@@ -1324,13 +1330,21 @@ static uint8_t XcpAddOdtEntry(uint32_t addr, uint8_t ext, uint8_t size) {
 #endif
                 return CRC_ACCESS_DENIED;
 
+    if (!XcpAdjustOdtSize(local.write_daq_daq, local.write_daq_odt, size))
+        return CRC_DAQ_CONFIG;
+
+#ifndef XCP_ENABLE_DAQ_ADDREXT
+    DaqListAddrExtMut(local.write_daq_daq) = ext;
+#endif
+#ifdef XCP_ENABLE_DYN_ADDRESSING
+    if (event != XCP_UNDEFINED_EVENT_ID)
+        DaqListEventChannelMut(local.write_daq_daq) = event;
+#endif
     DaqListOdtEntrySizeTableMut[local.write_daq_odt_entry] = size;
     DaqListOdtEntryAddrTableMut[local.write_daq_odt_entry] = base_offset; // Signed 32 bit offset relative to base pointer given to XcpEvent
 #ifdef XCP_ENABLE_DAQ_ADDREXT
     DaqListOdtEntryAddrExtTableMut[local.write_daq_odt_entry] = ext;
 #endif
-    if (!XcpAdjustOdtSize(local.write_daq_daq, local.write_daq_odt, size))
-        return CRC_DAQ_CONFIG;
     local_mut.write_daq_odt_entry++; // Autoincrement to next ODT entry, no autoincrementing over ODTs
     return 0;
 }
@@ -1353,6 +1367,9 @@ static uint8_t XcpSetDaqListMode(uint16_t daq, uint16_t event_id, uint8_t mode, 
     // Check if this event exists
     const tXcpEvent *event = XcpGetEvent(event_id); // Check if event exists
     if (event == NULL)
+        return CRC_OUT_OF_RANGE;
+#elif defined(XCP_MAX_EVENT_COUNT)
+    if (event_id >= XCP_MAX_EVENT_COUNT)
         return CRC_OUT_OF_RANGE;
 
 // Set the prescaler to the associated event, individual prescaler per DAQ list are not supported
@@ -1386,21 +1403,32 @@ static uint8_t XcpSetDaqListMode(uint16_t daq, uint16_t event_id, uint8_t mode, 
 #endif
 #endif
 
-    DaqListEventChannelMut(daq) = event_id;
-    DaqListModeMut(daq) = mode;
-    DaqListPriorityMut(daq) = prio;
-
     // Append daq to linked list of daq lists already associated to this event
 #ifdef XCP_MAX_EVENT_COUNT
     uint16_t daq0 = DaqListFirst(event_id);
-    uint16_t *daq0_next = &DaqListFirstMut(event_id);
-    while (daq0 != XCP_UNDEFINED_DAQ_LIST) {
-        assert(daq0 < shared.daq_lists.daq_count);
-        daq0 = DaqListNext(daq0);
-        daq0_next = &DaqListNextMut(daq0);
+    if (daq0 == XCP_UNDEFINED_DAQ_LIST) {
+        DaqListFirstMut(event_id) = daq;
+    } else {
+        for (;;) {
+            if (daq0 >= shared.daq_lists.daq_count) {
+                assert(false && "Invalid DAQ event list");
+                return CRC_DAQ_CONFIG;
+            }
+            if (daq0 == daq)
+                break; // DAQ list is already associated with this event
+            uint16_t next = DaqListNext(daq0);
+            if (next == XCP_UNDEFINED_DAQ_LIST) {
+                DaqListNextMut(daq0) = daq;
+                break;
+            }
+            daq0 = next;
+        }
     }
-    *daq0_next = daq;
 #endif
+
+    DaqListEventChannelMut(daq) = event_id;
+    DaqListModeMut(daq) = mode;
+    DaqListPriorityMut(daq) = prio;
 
     return 0;
 }

--- a/test/daq_config_test/src/main.c
+++ b/test/daq_config_test/src/main.c
@@ -1,0 +1,239 @@
+// daq_config_test
+// Tests dynamic DAQ configuration bounds and event-list linking through the XCP command processor.
+// No network server or XCP client is required.
+//
+// Build:
+//   cmake -B build -S . -DXCPLITE_BUILD_TESTS=ON
+//   cmake --build build --target daq_config_test
+// Run:
+//   ./build/daq_config_test
+
+#include <assert.h> // for assert
+#include <stdint.h> // for uintxx_t
+#include <stdio.h>  // for printf
+#include <string.h> // for memcpy
+
+// Public XCPlite API
+#include "xcplib.h" // for XcpEventExt, XcpSetLogLevel
+
+// Internal interfaces used to exercise the protocol command path without a network server.
+#include "queue.h"    // for the transmit queue
+#include "xcp.h"      // for XCP commands and error codes
+#include "xcp_cfg.h"  // for dynamic address encoding
+#include "xcplite.h"  // for the protocol-layer interface
+
+//-----------------------------------------------------------------------------------------------------
+// Test configuration
+
+#define TEST_QUEUE_SIZE ((size_t)16 * 1024)
+
+typedef union {
+    uint32_t words[XCPTL_MAX_CTO_SIZE / sizeof(uint32_t)];
+    uint8_t bytes[XCPTL_MAX_CTO_SIZE];
+} tTestCommand;
+
+static tQueueHandle test_queue;
+
+//-----------------------------------------------------------------------------------------------------
+// XCP command helpers
+
+// Encode integers in the little-endian byte order required by XCP.
+static void set_u16(uint8_t *p, uint16_t value) {
+    p[0] = (uint8_t)value;
+    p[1] = (uint8_t)(value >> 8);
+}
+
+static void set_u32(uint8_t *p, uint32_t value) {
+    p[0] = (uint8_t)value;
+    p[1] = (uint8_t)(value >> 8);
+    p[2] = (uint8_t)(value >> 16);
+    p[3] = (uint8_t)(value >> 24);
+}
+
+static uint8_t run_command(const uint8_t *data, uint8_t size) {
+    tTestCommand command = {0};
+    memcpy(command.bytes, data, size);
+    return XcpCommand(command.words, size);
+}
+
+// The following helpers construct complete XCP commands and execute them through XcpCommand().
+static uint8_t free_daq(void) {
+    const uint8_t command[] = {CC_FREE_DAQ};
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t alloc_daq(uint16_t count) {
+    uint8_t command[CRO_ALLOC_DAQ_LEN] = {CC_ALLOC_DAQ};
+    set_u16(&command[2], count);
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t alloc_odt(uint16_t daq, uint8_t count) {
+    uint8_t command[CRO_ALLOC_ODT_LEN] = {CC_ALLOC_ODT};
+    set_u16(&command[2], daq);
+    command[4] = count;
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t alloc_odt_entry(uint16_t daq, uint8_t odt, uint8_t count) {
+    uint8_t command[CRO_ALLOC_ODT_ENTRY_LEN] = {CC_ALLOC_ODT_ENTRY};
+    set_u16(&command[2], daq);
+    command[4] = odt;
+    command[5] = count;
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t set_daq_ptr(uint16_t daq, uint8_t odt, uint8_t entry) {
+    uint8_t command[CRO_SET_DAQ_PTR_LEN] = {CC_SET_DAQ_PTR};
+    set_u16(&command[2], daq);
+    command[4] = odt;
+    command[5] = entry;
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t write_daq(uint8_t size, uint8_t ext, uint32_t addr) {
+    uint8_t command[CRO_WRITE_DAQ_LEN] = {CC_WRITE_DAQ};
+    command[2] = size;
+    command[3] = ext;
+    set_u32(&command[4], addr);
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t set_daq_list_mode(uint16_t daq, uint16_t event) {
+    uint8_t command[CRO_SET_DAQ_LIST_MODE_LEN] = {CC_SET_DAQ_LIST_MODE};
+    command[1] = DAQ_MODE_TIMESTAMP;
+    set_u16(&command[2], daq);
+    set_u16(&command[4], event);
+    command[6] = 1;
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t start_stop_daq_list(uint16_t daq, uint8_t mode) {
+    uint8_t command[CRO_START_STOP_DAQ_LIST_LEN] = {CC_START_STOP_DAQ_LIST};
+    command[1] = mode;
+    set_u16(&command[2], daq);
+    return run_command(command, sizeof(command));
+}
+
+static uint8_t start_stop_synch(uint8_t mode) {
+    const uint8_t command[CRO_START_STOP_SYNCH_LEN] = {CC_START_STOP_SYNCH, mode};
+    return run_command(command, sizeof(command));
+}
+
+//-----------------------------------------------------------------------------------------------------
+// Regression tests
+
+// An oversized ALLOC_DAQ must be rejected before writing the DAQ table.
+// A valid allocation immediately afterwards verifies that the rejected command did not alter the state.
+static void test_daq_allocation_rollback(void) {
+    assert(alloc_daq(UINT16_MAX) == CRC_MEMORY_OVERFLOW);
+    assert(alloc_daq(1) == CRC_CMD_OK);
+    assert(free_daq() == CRC_CMD_OK);
+}
+
+// The first ODT allocation fits in the configured DAQ memory; the second does not.
+// Retrying with a smaller count verifies that the rejected allocation did not change the total ODT count.
+static void test_odt_allocation_rollback(void) {
+    assert(alloc_daq(2) == CRC_CMD_OK);
+    assert(alloc_odt(0, 200) == CRC_CMD_OK);
+    assert(alloc_odt(1, 200) == CRC_MEMORY_OVERFLOW);
+    assert(alloc_odt(1, 1) == CRC_CMD_OK);
+    assert(free_daq() == CRC_CMD_OK);
+}
+
+// Fill most of the DAQ memory with ODT entries, provoke an overflow, then retry with one entry.
+// The retry succeeds only if the rejected allocation preserved the previous ODT entry count.
+static void test_odt_entry_allocation_rollback(void) {
+    assert(alloc_daq(1) == CRC_CMD_OK);
+    assert(alloc_odt(0, 3) == CRC_CMD_OK);
+    assert(alloc_odt_entry(0, 0, 200) == CRC_CMD_OK);
+    assert(alloc_odt_entry(0, 1, 200) == CRC_CMD_OK);
+    assert(alloc_odt_entry(0, 2, 200) == CRC_MEMORY_OVERFLOW);
+    assert(alloc_odt_entry(0, 2, 1) == CRC_CMD_OK);
+    assert(free_daq() == CRC_CMD_OK);
+}
+
+// Four maximum-size entries fit into the first ODT. The fifth exceeds the DTO limit.
+// A smaller entry must still fit afterwards, proving that the failed write did not increase the ODT size.
+static void test_odt_size_rollback(tXcpEventId event) {
+    assert(alloc_daq(1) == CRC_CMD_OK);
+    assert(alloc_odt(0, 1) == CRC_CMD_OK);
+    assert(alloc_odt_entry(0, 0, 5) == CRC_CMD_OK);
+    assert(set_daq_ptr(0, 0, 0) == CRC_CMD_OK);
+
+    uint32_t addr = XcpAddrEncodeDyn(0, event);
+    for (uint8_t i = 0; i < 4; i++) {
+        assert(write_daq(XCPTL_MAX_CTO_SIZE, XCP_ADDR_EXT_DYN, addr) == CRC_CMD_OK);
+    }
+    assert(write_daq(XCPTL_MAX_CTO_SIZE, XCP_ADDR_EXT_DYN, addr) == CRC_DAQ_CONFIG);
+    assert(write_daq(24, XCP_ADDR_EXT_DYN, addr) == CRC_CMD_OK);
+    assert(free_daq() == CRC_CMD_OK);
+}
+
+static void configure_single_entry_daq(uint16_t daq, tXcpEventId event) {
+    assert(set_daq_ptr(daq, 0, 0) == CRC_CMD_OK);
+    assert(write_daq(sizeof(uint32_t), XCP_ADDR_EXT_DYN, XcpAddrEncodeDyn(0, event)) == CRC_CMD_OK);
+    assert(set_daq_list_mode(daq, event) == CRC_CMD_OK);
+}
+
+// Associate two DAQ lists with one event and repeat one association.
+// Triggering the event must produce one DTO per DAQ list without an out-of-bounds link or cycle.
+static void test_shared_event_daq_list(tXcpEventId event) {
+    assert(alloc_daq(2) == CRC_CMD_OK);
+    assert(alloc_odt(0, 1) == CRC_CMD_OK);
+    assert(alloc_odt(1, 1) == CRC_CMD_OK);
+    assert(alloc_odt_entry(0, 0, 1) == CRC_CMD_OK);
+    assert(alloc_odt_entry(1, 0, 1) == CRC_CMD_OK);
+    configure_single_entry_daq(0, event);
+    configure_single_entry_daq(1, event);
+
+    // Repeating the association must not append the same DAQ list again or form a cycle.
+    assert(set_daq_list_mode(0, event) == CRC_CMD_OK);
+
+    assert(start_stop_daq_list(0, 2) == CRC_CMD_OK);
+    assert(start_stop_daq_list(1, 2) == CRC_CMD_OK);
+    assert(start_stop_synch(1) == CRC_CMD_OK);
+
+    uint32_t measurement = 0x12345678;
+    XcpEventExt(event, (const uint8_t *)&measurement);
+
+    // Both DAQ lists must be reached exactly once through the event's linked list.
+    uint8_t dto_count = 0;
+    for (;;) {
+        tQueueBuffer dto = queuePeek(test_queue, 0, NULL, NULL);
+        if (dto.buffer == NULL)
+            break;
+        dto_count++;
+        queueRelease(test_queue, &dto);
+    }
+    assert(dto_count == 2);
+}
+
+//-----------------------------------------------------------------------------------------------------
+// Main
+
+int main(void) {
+    XcpSetLogLevel(0);
+    assert(XcpInit("daq_config_test", "1.0", XCP_MODE_LOCAL));
+
+    tXcpEventId event = XcpCreateEvent("test_event", 1000000, 0);
+    assert(event != XCP_UNDEFINED_EVENT_ID);
+
+    test_queue = queueInit(TEST_QUEUE_SIZE);
+    assert(test_queue != NULL);
+    XcpStart(test_queue, false);
+
+    const uint8_t connect[] = {CC_CONNECT, 0};
+    assert(run_command(connect, sizeof(connect)) == CRC_CMD_OK);
+
+    test_daq_allocation_rollback();
+    test_odt_allocation_rollback();
+    test_odt_entry_allocation_rollback();
+    test_odt_size_rollback(event);
+    test_shared_event_daq_list(event);
+
+    XcpDeinit();
+    queueDeinit(test_queue);
+    printf("DAQ configuration tests passed\n");
+    return 0;
+}

--- a/test/daq_config_test/src/xcptl_stub.c
+++ b/test/daq_config_test/src/xcptl_stub.c
@@ -1,0 +1,17 @@
+// Transport layer stub for daq_config_test
+// Command responses are irrelevant to this protocol-layer test and are intentionally discarded.
+
+#include <stdbool.h> // for bool
+#include <stdint.h>  // for uintxx_t
+
+#include "xcptl.h"
+
+bool XcpTlWaitForTransmitQueueEmpty(uint16_t timeout_ms) {
+    (void)timeout_ms;
+    return true;
+}
+
+void XcpTlSendCrm(const uint8_t *data, uint8_t size) {
+    (void)data;
+    (void)size;
+}


### PR DESCRIPTION
## Summary

Fix DAQ configuration commands that could partially modify internal state after returning an error, and make DAQ event-list linking safe and repeatable.

## Changes

- Validate proposed DAQ, ODT, and ODT-entry counts before updating configuration state.
- Preserve ODT sizes and entry metadata when WRITE_DAQ validation fails.
- Validate fixed event identifiers when no dynamic event list is available.
- Prevent invalid event-list traversal, duplicate links, and cycles when associating DAQ lists with events.
- Add focused regression tests covering allocation rollback, ODT-size rollback, and multiple DAQ lists sharing an event.
- Document the new daq_config_test target.

## Why

A rejected DAQ configuration command could previously leave counters or metadata partially updated. This made a valid retry fail or operate on inconsistent state.

Repeatedly associating a DAQ list with an event could also create an invalid linked list or cycle.

## Validation

- GCC build and regression test passed.
- Clang build and regression test passed.
- AddressSanitizer and UndefinedBehaviorSanitizer passed.
- All default test targets build successfully.
- Existing test targets retain their original compile configuration.
